### PR TITLE
feat: Add support for message type generation from Json schemas

### DIFF
--- a/artifacts/buildSrc/README.md
+++ b/artifacts/buildSrc/README.md
@@ -1,0 +1,91 @@
+# Introduction
+
+This directory contains the Schema Table Generator plugin. The generates readable type information in HTML for Json
+schema definitions found in the project source set.
+
+For example:
+
+```html
+
+<table class="message-table">
+    <tr>
+        <td class="message-class" colspan="3">MessageOffer</td>
+    </tr>
+    <tr>
+        <td class="message-properties-heading" colspan="3">Required properties</td>
+    </tr>
+    <tr>
+        <td class="code">@id</td>
+        <td>string</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class="code">@type</td>
+        <td>string</td>
+        <td>Value must be <span class="code">Offer</span></td>
+    </tr>
+    <tr>
+        <td class="message-properties-heading" colspan="3">Optional properties</td>
+    </tr>
+    <tr>
+        <td class="code">obligation</td>
+        <td>array</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class="code">permission</td>
+        <td>array</td>
+        <td></td>
+    </tr>
+    <tr>
+        <td class="code">profile</td>
+        <td>any</td>
+        <td></td>
+    </tr>
+</table>
+```
+
+For each type, a generated HTML table is created and output to `<build dir>/generated/tables`. File names are the
+typename in lowercase with an `.html` suffix. These files may then be imported into the ReSpec-based documentation using
+the `aside` element in the appropriate Markdown file:
+
+```html
+
+<aside data-include="generated/tables/messageoffer.html"></aside>
+```
+   
+## Implementation notes
+
+The Json Schema Object Model parser does not yet support all Json Schema features such `anyOf` or `oneOf`.  
+
+# Build Setup
+
+The plugin can be applied and configured as follows:
+
+```kotlin
+apply<SchemaTableGeneratorPlugin>();
+
+configure<SchemaTableGeneratorPluginExtension> {
+    schemaPrefix = "https://w3id.org/dspace/2024/1/"
+    schemaFileSuffix = "-schema.json"
+}
+```
+
+The `schemPrefix` property is used to specify the base URL for resolving schema references. This base URL will be mapped
+relative to where the schema files reside on the local filesystem. The `schemaFileSuffix` propery is used to filter
+schema files to include. 
+
+# Running
+
+The generation process can be run by specifying the `generateTablesFromSchemas` task:
+
+```
+./gradlew generateTablesFromSchemas
+```
+
+To debug the generation process, use:
+
+```
+./gradlew -Dorg.gradle.debug=true --no-daemon generateTablesFromSchemas
+```
+

--- a/artifacts/buildSrc/README.md
+++ b/artifacts/buildSrc/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This directory contains the Schema Table Generator plugin. The generates readable type information in HTML for Json
+This directory contains the Schema Table Generator plugin. The plugin generates readable type information in HTML for Json
 schema definitions found in the project source set.
 
 For example:

--- a/artifacts/buildSrc/build.gradle.kts
+++ b/artifacts/buildSrc/build.gradle.kts
@@ -1,6 +1,3 @@
-import org.eclipse.dsp.generation.SchemaTableGeneratorPlugin
-import org.eclipse.dsp.generation.SchemaTableGeneratorPluginExtension
-
 /*
  *  Copyright (c) 2024 Metaform Systems, Inc.
  *
@@ -20,27 +17,15 @@ plugins {
     checkstyle
 }
 
-apply<SchemaTableGeneratorPlugin>();
-
 repositories {
     mavenCentral()
-}
-
-configure<SchemaTableGeneratorPluginExtension> {
-    schemaPrefix = "https://w3id.org/dspace/2024/1/"
-    schemaFileSuffix = "-schema.json"
 }
 
 dependencies {
     implementation("com.networknt:json-schema-validator:1.5.2") {
         exclude("com.fasterxml.jackson.dataformat", "jackson-dataformat-yaml")
     }
-
     testImplementation("org.assertj:assertj-core:3.26.3")
-    testImplementation("com.apicatalog:titanium-json-ld:1.4.1")
-    testImplementation("org.glassfish:jakarta.json:2.0.1")
-    testImplementation("com.fasterxml.jackson.core:jackson-databind:2.18.0")
-    testImplementation("com.fasterxml.jackson.datatype:jackson-datatype-jakarta-jsonp:2.18.0")
 }
 
 testing {

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/SchemaTableGeneratorPlugin.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/SchemaTableGeneratorPlugin.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation;
+
+
+import org.eclipse.dsp.generation.jsom.JsomParser;
+import org.eclipse.dsp.generation.transformer.HtmlTableTransformer;
+import org.eclipse.dsp.generation.transformer.SchemaTypeTransformer;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.SourceSet;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Generates a table of schema properties to be included in the specification text.
+ */
+public class SchemaTableGeneratorPlugin implements Plugin<Project> {
+    private static final String TASK_NAME = "generateTablesFromSchemas";
+    public static final String CONFIG_NAME = "schemaTableGenerator";
+
+    private final SchemaTypeTransformer<String> htmlTransformer = new HtmlTableTransformer();
+
+    @Override
+    public void apply(@NotNull Project project) {
+        var extension = project.getExtensions().create(CONFIG_NAME, SchemaTableGeneratorPluginExtension.class);
+
+        project.task(TASK_NAME).doLast(task -> {
+            var tablesDir = task.getProject().getLayout().getBuildDirectory().dir("generated").get().dir("tables").getAsFile();
+            //noinspection ResultOfMethodCallIgnored
+            tablesDir.mkdirs();
+            var sourceSet = requireNonNull(project.getExtensions()
+                    .findByType(JavaPluginExtension.class)).getSourceSets().getByName("main");
+
+            var prefix = extension.getSchemaPrefix();
+            String resolvePath = getResolutionPath(sourceSet);
+
+            // parse the schema object model
+            var parser = new JsomParser(prefix, resolvePath);
+            var stream = sourceSet.getResources().getFiles().stream()
+                    .filter(f -> f.getName().endsWith(extension.getSchemaFileSuffix()));
+            var schemaModel = parser.parseFiles(stream);
+
+            schemaModel.getSchemaTypes().stream()
+                    .filter(type -> !type.isRootDefinition() && !type.isJsonBaseType())  // do not process built-in Json types and root schema types
+                    .forEach(type -> {
+                        var content = htmlTransformer.transform(type);
+                        var destination = new File(tablesDir, type.getName().toLowerCase() + ".html");
+                        try (var writer = new FileWriter(destination)) {
+                            writer.write(content);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+            task.getLogger().info("Completed generation");
+        });
+
+    }
+
+    private String getResolutionPath(SourceSet sourceSet) {
+        var files = sourceSet.getResources().getSourceDirectories().getFiles();
+        if (files.isEmpty()) {
+            throw new IllegalStateException("No schema resource directories found");
+        }
+        var path = files.iterator().next();
+        return path.getAbsolutePath().endsWith("/") ? path.getAbsolutePath() : path.getAbsolutePath() + "/";
+    }
+
+
+}

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/SchemaTableGeneratorPlugin.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/SchemaTableGeneratorPlugin.java
@@ -35,7 +35,9 @@ import static java.util.Objects.requireNonNull;
  */
 public class SchemaTableGeneratorPlugin implements Plugin<Project> {
     private static final String TASK_NAME = "generateTablesFromSchemas";
-    public static final String CONFIG_NAME = "schemaTableGenerator";
+    private static final String CONFIG_NAME = "schemaTableGenerator";
+    private static final String GENERATED = "generated";
+    private static final String TABLES = "tables";
 
     private final SchemaTypeTransformer<String> htmlTransformer = new HtmlTableTransformer();
 
@@ -44,7 +46,7 @@ public class SchemaTableGeneratorPlugin implements Plugin<Project> {
         var extension = project.getExtensions().create(CONFIG_NAME, SchemaTableGeneratorPluginExtension.class);
 
         project.task(TASK_NAME).doLast(task -> {
-            var tablesDir = task.getProject().getLayout().getBuildDirectory().dir("generated").get().dir("tables").getAsFile();
+            var tablesDir = task.getProject().getLayout().getBuildDirectory().dir(GENERATED).get().dir(TABLES).getAsFile();
             //noinspection ResultOfMethodCallIgnored
             tablesDir.mkdirs();
             var sourceSet = requireNonNull(project.getExtensions()

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/SchemaTableGeneratorPluginExtension.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/SchemaTableGeneratorPluginExtension.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation;
+
+/**
+ * Defines the plugin configuration.
+ */
+public class SchemaTableGeneratorPluginExtension {
+    private String schemaPrefix;
+    private String schemaFileSuffix = "-schema.json";
+
+    public SchemaTableGeneratorPluginExtension() {
+    }
+
+    public String getSchemaPrefix() {
+        return schemaPrefix;
+    }
+
+    public void setSchemaPrefix(String schemaPrefix) {
+        this.schemaPrefix = schemaPrefix;
+    }
+
+    public String getSchemaFileSuffix() {
+        return schemaFileSuffix;
+    }
+
+    public void setSchemaFileSuffix(String schemaFileSuffix) {
+        this.schemaFileSuffix = schemaFileSuffix;
+    }
+}

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/ElementDefinition.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/ElementDefinition.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.jsom;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Models an element such as {@code contains} object or an {@code items} object.
+ */
+public class ElementDefinition implements Comparable<ElementDefinition> {
+
+    public enum Type {
+        REFERENCE, CONSTANT
+    }
+
+    private final Type type;
+    private final String value;
+    private final Set<SchemaType> resolvedTypes = new TreeSet<>();
+
+    public ElementDefinition(Type type, String value) {
+        this.type = type;
+        this.value = value;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public Set<SchemaType> getResolvedTypes() {
+        return resolvedTypes;
+    }
+
+    public void resolvedType(SchemaType resolvedType) {
+        this.resolvedTypes.add(resolvedType);
+    }
+
+    @Override
+    public int compareTo(@NotNull ElementDefinition o) {
+        return value.compareTo(o.value);
+    }
+
+}

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/JsomParser.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/JsomParser.java
@@ -1,0 +1,251 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.jsom;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Stream.concat;
+import static org.eclipse.dsp.generation.jsom.ElementDefinition.Type.CONSTANT;
+import static org.eclipse.dsp.generation.jsom.ElementDefinition.Type.REFERENCE;
+import static org.eclipse.dsp.generation.jsom.JsonSchemaKeywords.ALL_OF;
+import static org.eclipse.dsp.generation.jsom.JsonSchemaKeywords.CONST;
+import static org.eclipse.dsp.generation.jsom.JsonSchemaKeywords.CONTAINS;
+import static org.eclipse.dsp.generation.jsom.JsonSchemaKeywords.DEFINITIONS;
+import static org.eclipse.dsp.generation.jsom.JsonSchemaKeywords.ITEMS;
+import static org.eclipse.dsp.generation.jsom.JsonSchemaKeywords.PROPERTIES;
+import static org.eclipse.dsp.generation.jsom.JsonSchemaKeywords.REF;
+import static org.eclipse.dsp.generation.jsom.JsonSchemaKeywords.REQUIRED;
+import static org.eclipse.dsp.generation.jsom.JsonSchemaKeywords.TYPE;
+import static org.eclipse.dsp.generation.jsom.JsonTypes.ANY;
+import static org.eclipse.dsp.generation.jsom.JsonTypes.ARRAY;
+
+/**
+ * Parses JSON Schemas into a JSON Schema Object Model (JSOM).
+ */
+public class JsomParser {
+    private final ObjectMapper mapper;
+    private final String prefix;
+    private final String resolutionPath;
+
+    public record SchemaInstance(String schemaPath, Map<String, Object> schema) {
+    }
+
+    /**
+     * Ctor
+     *
+     * @param prefix         the schema prefix used when referencing type definitions
+     * @param resolutionPath the local path that maps to the schema prefix
+     */
+    public JsomParser(String prefix, String resolutionPath) {
+        this(prefix, resolutionPath, new ObjectMapper());
+    }
+
+    /**
+     * Ctor
+     *
+     * @param prefix         the schema prefix used when referencing type definitions
+     * @param resolutionPath the local path that maps to the schema prefix
+     * @param mapper         an object mapper used for schema deserialization
+     */
+    public JsomParser(String prefix, String resolutionPath, ObjectMapper mapper) {
+        this.prefix = prefix;
+        this.resolutionPath = resolutionPath;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Parses a set of JSON schemas from the file locations and returns an object model representing the type system.
+     */
+    @SuppressWarnings("unchecked")
+    public SchemaModel parseFiles(Stream<File> files) {
+        var schemaContext = new SchemaModelContext();
+        files.flatMap(schemaFile -> {
+            try {
+                var root = mapper.readValue(schemaFile, Map.class);
+                return parseTypes(schemaFile.getAbsolutePath(), (Map<String, Object>) root);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }).forEach(schemaContext::addType);
+        schemaContext.resolve();
+        return schemaContext;
+    }
+
+    /**
+     * Parses a set of JSON schemas instances and returns an object model representing the type system.
+     */
+    public SchemaModel parseInstances(Stream<SchemaInstance> instances) {
+        var schemaContext = new SchemaModelContext();
+        instances.flatMap(instance -> parseTypes(instance.schemaPath(), instance.schema())).forEach(schemaContext::addType);
+        schemaContext.resolve();
+        return schemaContext;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Stream<SchemaType> parseTypes(String schemaPath, Map<String, Object> parsedSchema) {
+        var definitions = (Map<String, Object>) parsedSchema.getOrDefault(DEFINITIONS, Map.of());
+        var definitionsStream = definitions.entrySet().stream()
+                .map(entry -> parseTypeDefinition(entry.getKey(), schemaPath, (Map<String, Object>) entry.getValue()));
+
+        var rootAllOf = parsedSchema.get(ALL_OF);
+        if (rootAllOf != null) {
+            var rootType = parseRootType(schemaPath, parsedSchema);
+            return concat(Stream.of(rootType), definitionsStream);
+        }
+        return definitionsStream;
+
+    }
+
+    /**
+     * Parses a type definition at the schema root, i.e. its type name is the schema URI.
+     */
+    private @NotNull SchemaType parseRootType(String schemaPath, Map<String, Object> root) {
+        var typeName = prefix + schemaPath.substring(resolutionPath.length());
+        var baseType = root.getOrDefault(TYPE, ANY.getName()).toString();
+        var rootType = new SchemaType(typeName, baseType, true, typeName);
+        parseAttributes(root, rootType);
+        return rootType;
+    }
+
+    /**
+     * Parses a type definition at in the {@code definitions} schema property.
+     */
+    private @NotNull SchemaType parseTypeDefinition(String type, String schemaPath, Map<String, Object> definition) {
+        var baseType = definition.getOrDefault(TYPE, ANY.getName()).toString();
+        var context = prefix + schemaPath.substring(resolutionPath.length());
+        var schemaType = new SchemaType(type, baseType, context);
+        parseAttributes(definition, schemaType);
+        return schemaType;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void parseAttributes(Map<String, Object> definition, SchemaType schemaType) {
+        parseRequired(definition, schemaType);
+
+        // parse properties
+        var properties = (Map<String, Object>) definition.get(PROPERTIES);
+        if (properties != null) {
+            var schemaProperties = properties.entrySet().stream()
+                    .map(e -> parseProperty(e.getKey(), (Map<String, Object>) e.getValue()))
+                    .filter(Objects::nonNull)
+                    .toList();
+            schemaType.properties(schemaProperties);
+        }
+
+        // parse allOf properties
+        parseAllOf(definition, schemaType);
+
+        // parse contains
+        var contains = (Map<String, Object>) definition.get(CONTAINS);
+        if (contains != null) {
+            schemaType.contains(parseElementDefinition(contains));
+        }
+    }
+
+    private List<ElementDefinition> parseElementDefinition(Map<String, Object> container) {
+        var constantValue = (String) container.get(CONST);
+        if (constantValue != null) {
+            return List.of(new ElementDefinition(CONSTANT, constantValue));
+        } else {
+            var refValue = (String) container.get(REF);
+            if (refValue != null) {
+                return List.of(new ElementDefinition(REFERENCE, refValue));
+            }
+        }
+        return emptyList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private void parseAllOf(Map<String, Object> definition, SchemaType schemaType) {
+        var allOfDefinition = (List<Map<String, Object>>) definition.getOrDefault(ALL_OF, emptyList());
+        var allOfProperties = allOfDefinition.stream()
+                .map(e -> (Map<String, Object>) e.get(PROPERTIES))
+                .filter(Objects::nonNull)
+                .flatMap(e -> e.entrySet().stream())
+                .map(e -> parseProperty(e.getKey(), (Map<String, Object>) e.getValue()))
+                .toList();
+        schemaType.properties(allOfProperties);
+
+        // parse allOf references
+        var allOf = allOfDefinition
+                .stream()
+                .map(e -> e.get(REF))
+                .filter(Objects::nonNull)
+                .map(Object::toString)
+                .toList();
+        schemaType.allOf(allOf);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void parseRequired(Map<String, Object> definition, SchemaType schemaType) {
+        // parse required
+        var required = (List<String>) definition.get(REQUIRED);
+        if (required != null) {
+            var requiredFields = required.stream().map(SchemaPropertyReference::new).toList();
+            schemaType.required(requiredFields);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private SchemaProperty parseProperty(String name, Map<String, Object> value) {
+        var type = value.get(TYPE);
+        if (type == null) {
+            var ref = value.get(REF);
+            if (ref != null) {
+                return SchemaProperty.Builder.newInstance()
+                        .name(name)
+                        .types(Set.of((String) ref))
+                        .description("")
+                        .build();
+            }
+            // FIXME support anyOf, oneOf
+            return SchemaProperty.Builder.newInstance()
+                    .name(name)
+                    .types(Set.of(ANY.getName()))
+                    .description("")
+                    .build();
+        } else if (ARRAY.getBaseType().equals(type)) {
+            var property = SchemaProperty.Builder.newInstance()
+                    .name(name)
+                    .types(Set.of((String) type))
+                    .description("");
+            var items = value.get(ITEMS);
+            if (items instanceof Map) {
+                property.itemTypes(parseElementDefinition((Map<String, Object>) items));
+            }
+            return property.build();
+        } else {
+            var builder = SchemaProperty.Builder.newInstance()
+                    .name(name)
+                    .types(Set.of((String) type))
+                    .description("");
+            var constantValue = value.get(CONST);
+            if (constantValue != null) {
+                builder.constantValue(constantValue.toString());
+            }
+            return builder.build();
+        }
+    }
+}

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/JsomParser.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/JsomParser.java
@@ -220,7 +220,6 @@ public class JsomParser {
                         .description("")
                         .build();
             }
-            // FIXME support anyOf, oneOf
             return SchemaProperty.Builder.newInstance()
                     .name(name)
                     .types(Set.of(ANY.getName()))

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/JsonSchemaKeywords.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/JsonSchemaKeywords.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.jsom;
+
+/**
+ * Json Schema keywords.
+ */
+public interface JsonSchemaKeywords {
+    String REF = "$ref";
+    String ALL_OF = "allOf";
+    String ANY_OF = "anyOf";
+    String CONST = "const";
+    String CONTAINS = "contains";
+    String DEFINITIONS = "definitions";
+    String ITEMS = "items";
+    String ONE_OF = "oneOf";
+    String PROPERTIES = "properties";
+    String REQUIRED = "required";
+    String TYPE = "type";
+}

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/JsonTypes.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/JsonTypes.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.jsom;
+
+/**
+ * The Json Schema type system.
+ */
+public interface JsonTypes {
+
+    SchemaType STRING = new SchemaType("string");
+
+    SchemaType NUMBER = new SchemaType("number");
+
+    SchemaType INTEGER = new SchemaType("integer");
+
+    SchemaType OBJECT = new SchemaType("object");
+
+    SchemaType ARRAY = new SchemaType("array");
+
+    SchemaType BOOLEAN = new SchemaType("boolean");
+
+    SchemaType NULL = new SchemaType("null");
+
+    SchemaType ANY = new SchemaType("any");
+
+}

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaModel.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaModel.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.jsom;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+/**
+ * Represents a JSON Schema Object Model (JSOM).
+ */
+public interface SchemaModel {
+
+    /**
+     * Resolves a reference to a schema type for a given context or null if not found.
+     */
+    SchemaType resolveType(String reference, String typeContext);
+
+    /**
+     * Returns all schema types defined in the model.
+     */
+    @NotNull
+    Collection<SchemaType> getSchemaTypes();
+}

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaModelContext.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaModelContext.java
@@ -1,0 +1,155 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.jsom;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.eclipse.dsp.generation.jsom.ElementDefinition.Type.REFERENCE;
+import static org.eclipse.dsp.generation.jsom.JsonTypes.ANY;
+import static org.eclipse.dsp.generation.jsom.JsonTypes.ARRAY;
+import static org.eclipse.dsp.generation.jsom.JsonTypes.BOOLEAN;
+import static org.eclipse.dsp.generation.jsom.JsonTypes.INTEGER;
+import static org.eclipse.dsp.generation.jsom.JsonTypes.NULL;
+import static org.eclipse.dsp.generation.jsom.JsonTypes.NUMBER;
+import static org.eclipse.dsp.generation.jsom.JsonTypes.OBJECT;
+import static org.eclipse.dsp.generation.jsom.JsonTypes.STRING;
+
+/**
+ * Contains a Json Schema object model and its types.
+ * <p>
+ * Types must first be added to the context. After all types have been added, {@link #resolve()} will bind all type references in the model.
+ * For example, {@code $ref} entries will be linked to their actual parsed type instances.
+ */
+public class SchemaModelContext implements SchemaModel {
+    private static final String RELATIVE_REFERENCE = "#/definitions/";
+    private static final String POINTER_REFERENCE = "#definitions/";
+    private static final String POINTER_REFERENCE_SEPARATOR = "#/definitions/";
+
+    private final Map<String, SchemaType> schemaTypes = new HashMap<>();
+    private final Map<String, Map<String, SchemaType>> typesByContext = new HashMap<>();
+
+    public SchemaModelContext() {
+        // load built-in Json types
+        schemaTypes.put(STRING.getName(), STRING);
+        schemaTypes.put(NUMBER.getName(), NUMBER);
+        schemaTypes.put(INTEGER.getName(), INTEGER);
+        schemaTypes.put(OBJECT.getName(), OBJECT);
+        schemaTypes.put(ARRAY.getName(), ARRAY);
+        schemaTypes.put(BOOLEAN.getName(), BOOLEAN);
+        schemaTypes.put(NULL.getName(), NULL);
+        schemaTypes.put(ANY.getName(), ANY);
+    }
+
+    @Override
+    public SchemaType resolveType(String reference, String typeContext) {
+        if (reference.startsWith(RELATIVE_REFERENCE)) {
+            // resolve references relative to the schema definition, e.g. in "definitions"
+            var typesForContext = typesByContext.get(typeContext);
+            if (typesForContext != null) {
+                return typesForContext.get(reference.substring(RELATIVE_REFERENCE.length()));
+            }
+            return null;
+        } else if (reference.contains(POINTER_REFERENCE)) {
+            // reference of type https://<uri>>#definitions/SomeType
+            var tokens = reference.split(POINTER_REFERENCE);
+            if (tokens.length != 2) {
+                throw new UnsupportedOperationException("Unsupported reference type: " + reference);
+            }
+            return resolveType(RELATIVE_REFERENCE + tokens[1], tokens[0]);
+        } else if (reference.contains(POINTER_REFERENCE_SEPARATOR)) {
+            var tokens = reference.split(POINTER_REFERENCE_SEPARATOR);
+            if (tokens.length != 2) {
+                throw new UnsupportedOperationException("Unsupported reference type: " + reference);
+            }
+            return resolveType(RELATIVE_REFERENCE + tokens[1], tokens[0]);
+        } else {
+            // resolve a reference to an external schema
+            return schemaTypes.get(reference);
+        }
+    }
+
+    @NotNull
+    public Collection<SchemaType> getSchemaTypes() {
+        return schemaTypes.values();
+    }
+
+    public void addType(SchemaType type) {
+        schemaTypes.put(type.getName(), type);
+        typesByContext.computeIfAbsent(type.getSchemaUri(), k -> new HashMap<>()).put(type.getName(), type);
+    }
+
+    public void resolve() {
+        // resolve all schema type references and link them
+        var types = schemaTypes.values();
+        types.forEach(type -> type.getAllOf().stream()
+                .map(ref -> resolveType(ref, type.getSchemaUri()))
+                .filter(Objects::nonNull)
+                .forEach(type::resolvedAllOfType));
+
+        // resolve all property type references and link them
+        types.forEach(type -> type.getProperties()
+                .forEach(property -> property.getTypes().stream()
+                        .map((ref -> resolveType(ref, type.getSchemaUri())))
+                        .filter(Objects::nonNull)
+                        .forEach(property::resolvedType)));
+
+        // resolve required properties that do not reference properties explicitly defined on the type, e.g.
+        // required properties from types referenced in `allOf`
+        types.forEach(type -> type.getRequiredProperties()
+                .stream()
+                .filter(ref -> ref.getResolvedProperty() == null)
+                .forEach(ref -> {
+                    // check in allOf
+                    var resolved = type.getResolvedAllOf().stream()
+                            .flatMap(t -> t.getProperties().stream()
+                                    .map(p -> p.getName().equals(ref.getName()) ? p : null)
+                                    .filter(Objects::nonNull)).findFirst().orElse(null);
+
+                    ref.resolvedProperty(resolved);
+                }));
+
+
+        // resolve contains references
+        types.forEach(type -> type.getContains().stream().filter(cd -> cd.getType() == REFERENCE)
+                .forEach(cd -> {
+                    var resolved = resolveType(cd.getValue(), type.getSchemaUri());
+                    if (resolved != null) {
+                        cd.resolvedType(resolved);
+                    }
+                }));
+
+        // resolve array item references
+        types.forEach(type -> {
+            type.getProperties().stream()
+                    .flatMap(property -> property.getItemTypes().stream())
+                    .filter(item -> item.getType() == REFERENCE)
+                    .forEach(item -> {
+                        var resolved = resolveType(item.getValue(), type.getSchemaUri());
+                        if (resolved != null) {
+                            item.resolvedType(resolved);
+                        }
+                    });
+        });
+
+        // resolve required properties to the schema property definition
+        types.forEach(SchemaType::resolvePropertyReferences);
+
+    }
+}

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaProperty.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaProperty.java
@@ -1,0 +1,130 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.jsom;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+/**
+ * A property defined in a schema type.
+ */
+public class SchemaProperty implements Comparable<SchemaProperty> {
+    private String name;
+    private String description = "";
+    private String constantValue;
+    private Set<String> types = new TreeSet<>();
+    private final Set<SchemaType> resolvedTypes = new TreeSet<>();
+    private final Set<ElementDefinition> itemTypes = new TreeSet<>();
+
+    private SchemaProperty() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Set<String> getTypes() {
+        return types;
+    }
+
+    public String getConstantValue() {
+        return constantValue;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Set<SchemaType> getResolvedTypes() {
+        return resolvedTypes;
+    }
+
+    public void resolvedType(SchemaType resolvedType) {
+        this.resolvedTypes.add(resolvedType);
+    }
+
+    public Set<ElementDefinition> getItemTypes() {
+        return itemTypes;
+    }
+
+    @Override
+    public int compareTo(@NotNull SchemaProperty o) {
+        return name.compareTo(o.name);
+    }
+
+    @Override
+    public String toString() {
+        var b = new StringBuilder(name)
+                .append(": ")
+                .append(resolvedTypes.stream().map(SchemaType::getName).collect(joining(",")));
+        if (constantValue != null) {
+            b.append(" [").append(constantValue).append("]");
+        }
+        return b.toString();
+    }
+
+    public static final class Builder {
+        private final SchemaProperty property;
+
+        public static Builder newInstance() {
+            return new Builder();
+        }
+
+        public Builder name(String name) {
+            property.name = name;
+            return this;
+        }
+
+        public Builder description(String description) {
+            property.description = description;
+            return this;
+        }
+
+        public Builder types(Set<String> types) {
+            property.types = types;
+            return this;
+        }
+
+        public Builder itemTypes(Collection<ElementDefinition> elementTypes) {
+            property.itemTypes.addAll(elementTypes);
+            return this;
+        }
+
+        public Builder constantValue(String value) {
+            property.constantValue = value;
+            return this;
+        }
+
+        public SchemaProperty build() {
+            requireNonNull(property.name);
+            requireNonNull(property.description);
+            if (property.types.isEmpty()) {
+                property.types.add("any");
+            }
+            return property;
+        }
+
+        private Builder() {
+            property = new SchemaProperty();
+        }
+
+    }
+}

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaPropertyReference.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaPropertyReference.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.jsom;
+
+import org.jetbrains.annotations.NotNull;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A reference to a schema property.
+ */
+public class SchemaPropertyReference implements Comparable<SchemaPropertyReference> {
+    private final String name;
+    private SchemaProperty resolvedProperty;
+
+    public SchemaPropertyReference(String name) {
+        this.name = requireNonNull(name);
+    }
+
+    public SchemaPropertyReference(String name, SchemaProperty resolvedProperty) {
+        this.name = name;
+        this.resolvedProperty = resolvedProperty;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public SchemaProperty getResolvedProperty() {
+        return resolvedProperty;
+    }
+
+    public void resolvedProperty(SchemaProperty property) {
+        this.resolvedProperty = property;
+    }
+
+    @Override
+    public int compareTo(@NotNull SchemaPropertyReference o) {
+        return name.compareTo(o.name);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaType.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaType.java
@@ -1,0 +1,186 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.jsom;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Stream.concat;
+
+/**
+ * A Json Schema type.
+ * <p>
+ * {@link #getBaseType()} returns the JSON type, e.g. {@code object}, {@code array}, etc. of the type. {@link #getName()} returns
+ * the type name which is either the property name of its {@code definitions} entry in the schema, or if the type is defined
+ * in the root level of the schema, the latter's URI.
+ */
+public class SchemaType implements Comparable<SchemaType> {
+    private static final String JSON_BASE_URI = "urn:json";
+
+    private final String name;
+    private final String baseType;
+    private final boolean rootDefinition;
+    private final String schemaUri;
+    private final Set<String> allOf = new HashSet<>();
+    private final Set<SchemaType> resolvedAllOf = new HashSet<>();
+    private final Set<SchemaProperty> properties = new TreeSet<>();
+    private final Set<ElementDefinition> contains = new TreeSet<>();
+    private final Map<String, SchemaProperty> propertiesMap = new HashMap<>();
+    private final Map<String, SchemaPropertyReference> requiredProperties = new HashMap<>();
+    private final Map<String, SchemaPropertyReference> optionalProperties = new HashMap<>();
+
+    private boolean jsonBaseType; // denotes if this type represents a base Json type, e.g. string, object, array
+
+    /**
+     * Ctor for base Json types.
+     */
+    public SchemaType(String name) {
+        this(name, "any", JSON_BASE_URI);
+        this.jsonBaseType = true;
+    }
+
+    /**
+     * Creates a type which a base type "any".
+     */
+    public SchemaType(String name, String schemaUri) {
+        this(name, "any", schemaUri);
+    }
+
+    public SchemaType(String name, String baseType, String schemaUri) {
+        this(name, baseType, false, schemaUri);
+    }
+
+    public SchemaType(String name, String baseType, boolean rootDefinition, String schemaUri) {
+        this.name = name;
+        this.baseType = baseType;
+        this.rootDefinition = rootDefinition;
+        this.schemaUri = schemaUri;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isJsonBaseType() {
+        return jsonBaseType;
+    }
+
+    public String getBaseType() {
+        return baseType;
+    }
+
+    public boolean isRootDefinition() {
+        return rootDefinition;
+    }
+
+    public String getSchemaUri() {
+        return schemaUri;
+    }
+
+    @NotNull
+    public Set<SchemaProperty> getProperties() {
+        return properties;
+    }
+
+    public Collection<SchemaPropertyReference> getRequiredProperties() {
+        return requiredProperties.values();
+    }
+
+    @NotNull
+    public Set<SchemaPropertyReference> getTransitiveRequiredProperties() {
+        return concat(requiredProperties.values().stream(), resolvedAllOf.stream()
+                .flatMap(type -> type.getTransitiveRequiredProperties().stream()))
+                .collect((toCollection(TreeSet::new)));
+    }
+
+    @NotNull
+    public Set<SchemaPropertyReference> getTransitiveOptionalProperties() {
+        // a type by include multple other types (allOf) where a property is optional in one but mandatory in another - filter it
+        var required = getRequiredProperties().stream().map(SchemaPropertyReference::getName).collect(Collectors.toSet());
+        return concat(optionalProperties.values().stream(), resolvedAllOf.stream()
+                .flatMap(type -> type.getTransitiveOptionalProperties().stream()))
+                .filter(prop -> !required.contains(prop.getName()))  // filter required
+                .collect((toCollection(TreeSet::new)));
+    }
+
+    public void properties(List<SchemaProperty> schemaProperties) {
+        properties.addAll(schemaProperties);
+        schemaProperties.forEach(p -> propertiesMap.put(p.getName(), p));
+    }
+
+    public Set<ElementDefinition> getContains() {
+        return contains;
+    }
+
+    public void contains(Collection<ElementDefinition> collection) {
+        contains.addAll(collection);
+    }
+
+    @NotNull
+    public Set<String> getAllOf() {
+        return allOf;
+    }
+
+    public Set<SchemaType> getResolvedAllOf() {
+        return resolvedAllOf;
+    }
+
+    public void allOf(Collection<String> allOf) {
+        this.allOf.addAll(allOf);
+    }
+
+    public void resolvedAllOfType(SchemaType type) {
+        this.resolvedAllOf.add(type);
+    }
+
+    public void required(Collection<SchemaPropertyReference> required) {
+        required.forEach(ref -> requiredProperties.put(ref.getName(), ref));
+    }
+
+    public void resolvePropertyReferences() {
+        // resolve required properties that have not yet been previously resolved, e.g. those directly defined on the type
+        requiredProperties.values()
+                .stream()
+                .filter(ref -> ref.getResolvedProperty() == null)
+                .forEach(ref -> ref.resolvedProperty(propertiesMap.get(ref.getName())));
+
+        // populate optional properties
+        properties.stream()
+                .filter(p -> !requiredProperties.containsKey(p.getName()))
+                .forEach(property -> optionalProperties.put(property.getName(), new SchemaPropertyReference(property.getName(), property)));
+    }
+
+    @Override
+    public int compareTo(@NotNull SchemaType o) {
+        return name.compareTo(o.name);
+    }
+
+    @Override
+    public String toString() {
+        return "SchemaType{" +
+               "name='" + name + '\'' +
+               ", baseType='" + baseType + '\'' +
+               '}';
+    }
+}

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/transformer/HtmlTableTransformer.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/transformer/HtmlTableTransformer.java
@@ -1,0 +1,141 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.transformer;
+
+import org.eclipse.dsp.generation.jsom.ElementDefinition;
+import org.eclipse.dsp.generation.jsom.SchemaProperty;
+import org.eclipse.dsp.generation.jsom.SchemaPropertyReference;
+import org.eclipse.dsp.generation.jsom.SchemaType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Stream.concat;
+import static org.eclipse.dsp.generation.jsom.ElementDefinition.Type.CONSTANT;
+import static org.eclipse.dsp.generation.jsom.JsonTypes.OBJECT;
+
+/**
+ * Transforms a {@link SchemaType} into an HTML table representation.
+ */
+public class HtmlTableTransformer implements SchemaTypeTransformer<String> {
+
+    @Override
+    @NotNull
+    public String transform(SchemaType schemaType) {
+        var builder = new StringBuilder(CSS).append("<table class=\"message-table\">");
+        builder.append(format("<tr><td class=\"message-class\" colspan=\"3\">%s</td></tr>", schemaType.getName()));
+        transformProperties("Required", schemaType.getTransitiveRequiredProperties(), builder);
+        transformProperties("Optional", schemaType.getTransitiveOptionalProperties(), builder);
+        return builder.append("</table>").toString();
+    }
+
+    private void transformProperties(String title, Set<SchemaPropertyReference> references, StringBuilder builder) {
+        if (!references.isEmpty()) {
+            builder.append(format("<tr><td class=\"message-properties-heading\" colspan=\"3\">%s properties</td></tr>", title));
+            references.forEach(propertyReference -> transformProperty(propertyReference, builder));
+        }
+    }
+
+    private void transformProperty(SchemaPropertyReference propertyReference, StringBuilder builder) {
+        builder.append("<tr>");
+        builder.append(format("<td class=\"code\">%s</td>", propertyReference.getName()));
+        var resolvedProperty = propertyReference.getResolvedProperty();
+        if (resolvedProperty != null) {
+            String resolvedTypes = "";
+            if (!resolvedProperty.getItemTypes().isEmpty()) {
+                resolvedTypes = getArrayTypeName(resolvedProperty);
+            } else {
+                resolvedTypes = resolvedProperty
+                        .getResolvedTypes().stream().map(this::getTypeName).collect(joining(", "));
+            }
+            builder.append(format("<td>%s</td>", resolvedTypes));
+            if (resolvedProperty.getConstantValue() != null) {
+                builder.append(format("<td>Value must be <span class=\"code\">%s</span></td>", resolvedProperty.getConstantValue()));
+            } else {
+                var constants = resolvedProperty.getResolvedTypes().stream()
+                        .flatMap(t -> concat(Stream.of(t), t.getResolvedAllOf().stream()))   // search the contains of the current type and any references 'allOf' types
+                        .flatMap(t -> t.getContains().stream())
+                        .filter(cd -> cd.getType() == CONSTANT)
+                        .map(ElementDefinition::getValue)
+                        .collect(Collectors.joining("<br> "));
+                if (constants.isEmpty()) {
+                    builder.append(format("<td>%s</td>", resolvedProperty.getDescription()));
+                } else {
+                    builder.append(format("<td>Must contain the following:<br><span class=\"code\">%s</span></td>", constants));
+                }
+            }
+        }
+        builder.append("</tr>");
+    }
+
+    private @NotNull String getArrayTypeName(SchemaProperty resolvedProperty) {
+        var itemTypes = resolvedProperty.getItemTypes().stream()
+                .flatMap(t -> t.getResolvedTypes().stream()).map(this::getTypeName)
+                .collect(joining(", "));
+        if (itemTypes.isEmpty()) {
+            return "array";
+        }
+        return "array[" + itemTypes + "]";
+    }
+
+    private String getTypeName(SchemaType schemaType) {
+        if (schemaType.isRootDefinition()) {
+            // root definition, check to see if it has an allOf, and if not, fallback to the Json base type
+            if (!schemaType.getResolvedAllOf().isEmpty()) {
+                // ue the allOf types and return the type name if it is a Json base object type; otherwise use the base type name
+                return schemaType.getResolvedAllOf().stream()
+                        .map(t -> OBJECT.getName().equals(t.getBaseType()) ? t.getName() : t.getBaseType())
+                        .collect(joining(", "));
+            }
+            return schemaType.getBaseType();
+        }
+        return schemaType.getName();
+    }
+
+    private static final String CSS = """
+            <style type="text/css">
+                .code {
+                    font-family: 'Courier New', monospace
+                }
+            
+                .message-class {
+                    font-weight: 600;
+                    font-size: 1.1rem;
+                    background-color: #FAFAFA;
+                }
+            
+                .message-properties-heading {
+                    font-weight: 600;
+                }
+            
+                .message-table {
+                    border-collapse: collapse;
+            
+                    tr {
+                        vertical-align: top !important;
+                    }
+            
+                    td {
+                        padding: 8px;
+                        border: 1px solid #DADADA;
+                    }
+                }
+            </style>
+            """;
+}

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/transformer/SchemaTypeTransformer.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/transformer/SchemaTypeTransformer.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.transformer;
+
+import org.eclipse.dsp.generation.jsom.SchemaType;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Transforms a {@link SchemaType} to an output format.
+ */
+public interface SchemaTypeTransformer<OUTPUT> {
+
+    @NotNull
+    OUTPUT transform(SchemaType schemaType);
+
+}

--- a/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/jsom/JsomParserTest.java
+++ b/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/jsom/JsomParserTest.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.jsom;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dsp.generation.jsom.TestSchema.TEST_SCHEMA;
+
+class JsomParserTest {
+    private static final String LOCAL = "/local/";
+    private static final String SCHEMA_PREFIX = "http://foo.com/schema/";
+    private ObjectMapper mapper;
+    private JsomParser parser;
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void verifyParse() throws JsonProcessingException {
+        var schema = (Map<String, Object>) mapper.readValue(TEST_SCHEMA, Map.class);
+        var schemaModel = parser.parseInstances(Stream.of(new JsomParser.SchemaInstance(LOCAL + "foo.json", schema)));
+
+        assertThat(schemaModel.getSchemaTypes()).isNotEmpty();
+
+        var policyClass = schemaModel.resolveType("PolicyClass", LOCAL);
+        var agreement = schemaModel.resolveType("Agreement", LOCAL);
+        assertThat(agreement.getResolvedAllOf()).contains(policyClass);
+        assertThat(agreement.getProperties().size()).isEqualTo(5);    // Agreement should have 5 properties
+        assertThat(agreement.getTransitiveRequiredProperties().size()).isEqualTo(5);
+        assertThat(agreement.getTransitiveOptionalProperties().size()).isEqualTo(4);
+
+
+    }
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ObjectMapper();
+        parser = new JsomParser(SCHEMA_PREFIX, LOCAL, mapper);
+    }
+}

--- a/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/jsom/SchemaModelContextTest.java
+++ b/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/jsom/SchemaModelContextTest.java
@@ -1,0 +1,125 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.jsom;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SchemaModelContextTest {
+    private SchemaModelContext modelContext;
+
+    @Test
+    public void verifyResolveRelativeReference() {
+        modelContext.addType(new SchemaType("Foo", "SchemaFile"));
+        assertThat(modelContext.resolveType("Foo", "SchemaFile")).isNotNull();
+        assertThat(modelContext.resolveType("#/definitions/Foo", "SchemaFile")).isNotNull();
+    }
+
+    @Test
+    void verifyResolveReferenceToAnotherFile() {
+        modelContext.addType(new SchemaType("Foo", "SchemaFile"));
+        assertThat(modelContext.resolveType("SchemaFile#/definitions/Foo", "AnotherContext")).isNotNull();
+        assertThat(modelContext.resolveType("SchemaFile#definitions/Foo", "AnotherContext")).isNotNull();
+    }
+
+    @Test
+    void verifyPropertyTypeResolution() {
+        var fooSchema = new SchemaType("Foo", "SchemaFile");
+        var barSchema = new SchemaType("Bar", "SchemaFile");
+
+        var fooProperty = SchemaProperty.Builder.newInstance()
+                .name("foo")
+                .types(Set.of("#/definitions/Foo"))
+                .build();
+
+        var fooArrayProperty = SchemaProperty.Builder.newInstance()
+                .name("fooArray")
+                .types(Set.of("array"))
+                .itemTypes(Set.of(new ElementDefinition(ElementDefinition.Type.REFERENCE, "#/definitions/Foo")))
+                .build();
+
+        var stringProperty = SchemaProperty.Builder.newInstance()
+                .name("stringProperty")
+                .types(Set.of("string"))
+                .build();
+
+
+        barSchema.properties(List.of(fooProperty, fooArrayProperty, stringProperty));
+        modelContext.addType(fooSchema);
+        modelContext.addType(barSchema);
+        modelContext.resolve();
+
+        assertThat(fooProperty.getResolvedTypes().size()).isEqualTo(1);
+        assertThat(fooProperty.getResolvedTypes()).contains(fooSchema);
+
+        assertThat(fooArrayProperty.getItemTypes().iterator().next().getResolvedTypes()).contains(fooSchema);
+        assertThat(stringProperty.getResolvedTypes()).contains(JsonTypes.STRING);
+    }
+
+    @Test
+    void verifyAllOfTypeResolution() {
+        var abstractFooSchema = new SchemaType("AbstractFoo", "SchemaFile");
+
+        var abstractProperty = SchemaProperty.Builder.newInstance()
+                .name("abstractProperty")
+                .types(Set.of("#/definitions/Foo"))
+                .build();
+
+        var abstractRequiredProperty = SchemaProperty.Builder.newInstance()
+                .name("abstractRequiredProperty")
+                .types(Set.of("string"))
+                .build();
+
+        abstractFooSchema.properties(List.of(abstractProperty, abstractRequiredProperty));
+
+        var fooSchema = new SchemaType("Foo", "SchemaFile");
+        fooSchema.allOf(Set.of("#/definitions/AbstractFoo"));
+        fooSchema.required(Set.of(new SchemaPropertyReference("abstractRequiredProperty")));
+
+        modelContext.addType(abstractFooSchema);
+        modelContext.addType(fooSchema);
+        modelContext.resolve();
+
+        assertThat(fooSchema.getTransitiveOptionalProperties().size()).isEqualTo(1);
+        assertThat(fooSchema.getTransitiveOptionalProperties().iterator().next().getResolvedProperty()).isSameAs(abstractProperty);
+
+        assertThat(fooSchema.getTransitiveRequiredProperties().size()).isEqualTo(1);
+        assertThat(fooSchema.getTransitiveRequiredProperties().iterator().next().getResolvedProperty()).isSameAs(abstractRequiredProperty);
+    }
+
+    @Test
+    void verifyContainsTypeResolution() {
+        var fooSchema = new SchemaType("Foo", "SchemaFile");
+        var barSchema = new SchemaType("Bar", "SchemaFile");
+
+        barSchema.contains(Set.of(new ElementDefinition(ElementDefinition.Type.REFERENCE, "#/definitions/Foo")));
+
+        modelContext.addType(fooSchema);
+        modelContext.addType(barSchema);
+        modelContext.resolve();
+
+        assertThat(barSchema.getContains().iterator().next().getResolvedTypes().iterator().next()).isEqualTo(fooSchema);
+    }
+
+    @BeforeEach
+    void setUp() {
+        modelContext = new SchemaModelContext();
+    }
+}

--- a/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/jsom/SchemaTypeTest.java
+++ b/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/jsom/SchemaTypeTest.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.jsom;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SchemaTypeTest {
+
+    @Test
+    void verifyResolvePropertyReferences() {
+        var fooSchema = new SchemaType("Bar", "SchemaFile");
+
+        var requiredProperty = SchemaProperty.Builder.newInstance()
+                .name("requiredProperty")
+                .types(Set.of("string"))
+                .build();
+
+        var optionalProperty = SchemaProperty.Builder.newInstance()
+                .name("optionalProperty")
+                .types(Set.of("string"))
+                .build();
+
+        fooSchema.properties(List.of(requiredProperty, optionalProperty));
+        fooSchema.required(Set.of(new SchemaPropertyReference("requiredProperty")));
+
+        fooSchema.resolvePropertyReferences();
+
+        assertThat(fooSchema.getTransitiveRequiredProperties().size()).isEqualTo(1);
+        assertThat(fooSchema.getTransitiveRequiredProperties().iterator().next().getResolvedProperty()).isEqualTo(requiredProperty);
+
+        assertThat(fooSchema.getTransitiveOptionalProperties().size()).isEqualTo(1);
+        assertThat(fooSchema.getTransitiveOptionalProperties().iterator().next().getResolvedProperty()).isEqualTo(optionalProperty);
+
+    }
+
+    @Test
+    void verifyTransitiveProperties() {
+        var abstractFooSchema = new SchemaType("AbstractFoo", "SchemaFile");
+
+        var abstractProperty = SchemaProperty.Builder.newInstance()
+                .name("abstractProperty")
+                .types(Set.of("string"))
+                .build();
+
+        var abstractRequiredProperty = SchemaProperty.Builder.newInstance()
+                .name("abstractRequiredProperty")
+                .types(Set.of("string"))
+                .build();
+
+        abstractFooSchema.properties(List.of(abstractProperty, abstractRequiredProperty));
+
+        var fooSchema = new SchemaType("Foo", "SchemaFile");
+        var abstractRequiredReference = new SchemaPropertyReference("abstractRequiredProperty");
+        fooSchema.required(Set.of(abstractRequiredReference));
+        fooSchema.resolvedAllOfType(abstractFooSchema);
+
+        abstractFooSchema.resolvePropertyReferences();
+        fooSchema.resolvePropertyReferences();
+
+        assertThat(fooSchema.getTransitiveRequiredProperties().size()).isEqualTo(1);
+        assertThat(fooSchema.getTransitiveRequiredProperties().iterator().next()).isSameAs(abstractRequiredReference);
+
+        assertThat(fooSchema.getTransitiveOptionalProperties().size()).isEqualTo(1);
+        assertThat(fooSchema.getTransitiveOptionalProperties().iterator().next().getName()).isSameAs(abstractProperty.getName());
+
+    }
+}

--- a/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/jsom/TestSchema.java
+++ b/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/jsom/TestSchema.java
@@ -1,0 +1,352 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.jsom;
+
+/**
+ * Schema for testing.
+ */
+public interface TestSchema {
+
+    String TEST_SCHEMA = """
+            {
+              "$schema": "https://json-schema.org/draft/2019-09/schema",
+              "title": "PolicySchema",
+              "type": "object",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Policy"
+                }
+              ],
+              "$id": "https://w3id.org/dspace/2024/1/negotiation/contract-schema.json",
+              "definitions": {
+                "Policy": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/MessageOffer"
+                    },
+                    {
+                      "$ref": "#/definitions/Offer"
+                    },
+                    {
+                      "$ref": "#/definitions/Agreement"
+                    }
+                  ]
+                },
+                "PolicyClass": {
+                  "type": "object",
+                  "properties": {
+                    "@id": {
+                      "type": "string"
+                    },
+                    "profile": {
+                      "oneOf": [
+                        {
+                          "type": "array",
+                          "items": "string"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "permission": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Permission"
+                      },
+                      "minItems": 1
+                    },
+                    "obligation": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Duty"
+                      },
+                      "minItems": 1
+                    }
+                  },
+                  "required": [
+                    "@id"
+                  ]
+                },
+                "MessageOffer": {
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/PolicyClass"
+                    },
+                    {
+                      "properties": {
+                        "@type": {
+                          "type": "string",
+                          "const": "Offer"
+                        }
+                      }
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "required": [
+                            "permission"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "prohibition"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "@type"
+                  ]
+                },
+                "Offer": {
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/MessageOffer"
+                    }
+                  ],
+                  "not": {
+                    "required": [
+                      "target"
+                    ]
+                  }
+                },
+                "Agreement": {
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "$ref": "#/definitions/PolicyClass"
+                    },
+                    {
+                      "properties": {
+                        "@type": {
+                          "type": "string",
+                          "const": "Agreement"
+                        },
+                        "target": {
+                          "type": "string"
+                        },
+                        "assigner": {
+                          "type": "string"
+                        },
+                        "assignee": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "string",
+                          "pattern": "-?([1-9][0-9]{3,}|0[0-9]{3})-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\\\\.[0-9]+)?|(24:00:00(\\\\.0+)?))(Z|(\\\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?"
+                        }
+                      }
+                    },
+                    {
+                      "anyOf": [
+                        {
+                          "required": [
+                            "permission"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "prohibition"
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "required": [
+                    "@type",
+                    "target",
+                    "assignee",
+                    "assigner"
+                  ]
+                },
+                "Permission": {
+                  "type": "object",
+                  "properties": {
+                    "action": {
+                      "$ref": "#/definitions/Action"
+                    },
+                    "constraint": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Constraint"
+                      }
+                    },
+                    "duty": {
+                      "$ref": "#/definitions/Duty"
+                    }
+                  },
+                  "required": [
+                    "action"
+                  ]
+                },
+                "Duty": {
+                  "type": "object",
+                  "allOf": [
+                    {
+                      "properties": {
+                        "action": {
+                          "$ref": "#/definitions/Action"
+                        },
+                        "constraint": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/definitions/Constraint"
+                          }
+                        }
+                      },
+                      "required": [
+                        "action"
+                      ]
+                    }
+                  ]
+                },
+                "Action": {
+                  "type": "string"
+                },
+                "Constraint": {
+                  "type": "object",
+                  "oneOf": [
+                    {
+                      "$ref": "#/definitions/LogicalConstraint"
+                    },
+                    {
+                      "$ref": "#/definitions/AtomicConstraint"
+                    }
+                  ]
+                },
+                "LogicalConstraint": {
+                  "type": "object",
+                  "properties": {
+                    "and": {
+                      "type": "array",
+                      "items": "object"
+                    },
+                    "andSequence": {
+                      "type": "array",
+                      "items": "object"
+                    },
+                    "or": {
+                      "type": "array",
+                      "items": {
+                        "oneOf": [
+                          {
+                            "$ref": "#/definitions/LogicalConstraint"
+                          },
+                          {
+                            "$ref": "#/definitions/AtomicConstraint"
+                          }
+                        ]
+                      }
+                    },
+                    "xone": {
+                      "type": "array",
+                      "items": "object"
+                    }
+                  },
+                  "oneOf": [
+                    {
+                      "required": [
+                        "and"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "andSequence"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "or"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "xone"
+                      ]
+                    }
+                  ]
+                },
+                "AtomicConstraint": {
+                  "type": "object",
+                  "properties": {
+                    "rightOperand": {
+                      "$ref": "#/definitions/RightOperand"
+                    },
+                    "leftOperand": {
+                      "$ref": "#/definitions/LeftOperand"
+                    },
+                    "operator": {
+                      "$ref": "#/definitions/Operator"
+                    }
+                  },
+                  "required": [
+                    "rightOperand",
+                    "operator",
+                    "leftOperand"
+                  ]
+                },
+                "Operator": {
+                  "type": "string",
+                  "enum": [
+                    "eq",
+                    "gt",
+                    "gteq",
+                    "lteq",
+                    "hasPart",
+                    "isA",
+                    "isAllOf",
+                    "isAnyOf",
+                    "isNoneOf",
+                    "isPartOf",
+                    "lt",
+                    "term-lteq",
+                    "neq"
+                  ]
+                },
+                "RightOperand": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object"
+                    },
+                    {
+                      "type": "array"
+                    }
+                  ]
+                },
+                "LeftOperand": {
+                  "type": "string"
+                },
+                "Reference": {
+                  "type": "object",
+                  "properties": {
+                    "@id": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "@id"
+                  ]
+                }
+              }
+            }
+            """;
+}

--- a/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/transformer/HtmlTableTransformerTest.java
+++ b/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/transformer/HtmlTableTransformerTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2024 Metaform Systems, Inc.
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Metaform Systems, Inc. - initial API and implementation
+ *
+ */
+
+package org.eclipse.dsp.generation.transformer;
+
+import org.eclipse.dsp.generation.jsom.ElementDefinition;
+import org.eclipse.dsp.generation.jsom.SchemaProperty;
+import org.eclipse.dsp.generation.jsom.SchemaPropertyReference;
+import org.eclipse.dsp.generation.jsom.SchemaType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.dsp.generation.jsom.JsonTypes.ARRAY;
+import static org.eclipse.dsp.generation.jsom.JsonTypes.STRING;
+
+class HtmlTableTransformerTest {
+    private HtmlTableTransformer transformer;
+
+    @Test
+    void verifyTransform() {
+        var barType = new SchemaType("Bar");
+        var fooType = new SchemaType("Foo");
+
+        var prop1 = SchemaProperty.Builder.newInstance()
+                .name("prop1")
+                .types(Set.of("#/definitions/Bar"))
+                .build();
+        prop1.resolvedType(barType);
+
+        var prop2 = SchemaProperty.Builder.newInstance()
+                .name("prop2")
+                .types(Set.of(STRING.getName()))
+                .build();
+        prop2.resolvedType(STRING);
+
+        var arrayElement = new ElementDefinition(ElementDefinition.Type.REFERENCE, "#/definitions/Bar");
+        arrayElement.resolvedType(barType);
+        var prop3 = SchemaProperty.Builder.newInstance()
+                .name("prop3")
+                .types(Set.of(ARRAY.getName()))
+                .itemTypes(Set.of(arrayElement))
+                .build();
+        prop3.resolvedType(ARRAY);
+
+        var propertyReference = new SchemaPropertyReference("prop3");
+        propertyReference.resolvedProperty(prop3);
+
+        fooType.properties(List.of(prop1, prop2, prop3));
+        fooType.required(Set.of(propertyReference));
+
+        fooType.resolvePropertyReferences();
+        barType.resolvePropertyReferences();
+
+        var result = transformer.transform(fooType);
+
+        assertThat(result.contains("<td class=\"message-class\" colspan=\"3\">Foo</td><")).isTrue(); // verify type name
+        assertThat(result.contains("Required properties</td>")).isTrue(); // verify required properties
+        assertThat(result.contains("Optional properties</td>")).isTrue(); // verify optional properties
+        assertThat(result.contains("<td>string</td>")).isTrue(); // verify property type names are included
+        assertThat(result.contains("array[Bar]")).isTrue();  // verify array type names are included
+    }
+
+    @BeforeEach
+    void setUp() {
+        transformer = new HtmlTableTransformer();
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

This PR generates HTML tables containing relevant type information (e.g., required and optional properties) for all DSP messages. The HTML tables are generated by a custom Gradle Plugin that parses the DSP schemas at build-time. The generated tables may then be directly included in ReSpec markdown.

The PR introduces the plugin and Json Schema Object Model parser thatis used to generate the tables. Subsequent PRs will include the generated tables in the specification text and remove the relevant PNG images and manually-created type information.   

Support for `$comment` or `description` still needs to be added. That can be done in another PR.

The plugin could be enhanced to provide hyperlinks for referenced type information. For example, a `MessageOffer` references the `Offer` type. The plugin could include a hyperlink directly to the `Offer` definition. We need to decide on the conventions for doing this.

## Why it does that

Enhances spec consistency and reduces the chance for errors.

## Further notes

_List other areas of the documents that have changed but are not necessarily linked to the main feature. This could be editorial changes or mistakes in example files that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes #62 
