### PR TITLE
fix: Fixes the dataset type to include a `@context`

### DIFF
--- a/artifacts/src/main/resources/catalog/dataset-schema.json
+++ b/artifacts/src/main/resources/catalog/dataset-schema.json
@@ -4,7 +4,7 @@
   "type": "object",
   "allOf": [
     {
-      "$ref": "#/definitions/Dataset"
+      "$ref": "#/definitions/RootDataset"
     }
   ],
   "$id": "https://w3id.org/dspace/2024/1/catalog/dataset-schema.json",
@@ -45,6 +45,22 @@
       "required": [
         "hasPolicy",
         "distribution"
+      ]
+    },
+    "RootDataset": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Dataset"
+        }
+      ],
+      "properties": {
+        "@context": {
+          "$ref": "https://w3id.org/dspace/2024/1/common/context-schema.json"
+        }
+      },
+      "required": [
+        "@context"
       ]
     },
     "Resource": {

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/catalog/DatasetSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/catalog/DatasetSchemaTest.java
@@ -35,6 +35,9 @@ public class DatasetSchemaTest extends AbstractSchemaTest {
 
     private static final String DATASET = """
             {
+              "@context": [
+                "https://w3id.org/dspace/2024/1/context.json"
+              ],
               "@id": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
               "hasPolicy": [
                 {


### PR DESCRIPTION
## What this PR changes/adds

The `Dataset` schema for dataset response messages does not contain an `@context` constraint. This is fixed by introducing a `RootDataset` type similar to `RootCatalog` that requires `@context` for use in response messages. However, when a dataset is contained in a catalog, the original `Dataset` type is used without `@context`.

## Linked Issue(s)

Closes #80 