### PR TITLE
fix: remove normative references to ODRL and DCAT

### DIFF
--- a/specifications/catalog/catalog.binding.https.md
+++ b/specifications/catalog/catalog.binding.https.md
@@ -50,7 +50,7 @@ Authorization: ...</pre>
 ##### Response
 
 If the request is successful, the [=Catalog Service=] must return an HTTP 200 (OK) with a response body containing
-a [Catalog](#ack-catalog) (which is a profiled [DCAT Catalog](https://www.w3.org/TR/vocab-dcat-3/#Class:Catalog) type described by the [=Catalog Protocol=]).
+a [Catalog](#ack-catalog).
 
 <aside class="example" title="Catalog Response">
     <pre class="json" data-include="message/example/catalog.json">

--- a/specifications/common/scope.md
+++ b/specifications/common/scope.md
@@ -4,7 +4,7 @@ Sharing data between autonomous entities requires the provision of metadata to f
 by making use of a data transfer (or application layer) protocol.
 The __Dataspace Protocol__ defines how this metadata is provisioned:
 
-1. How [=Datasets=] are advertised via DCAT [=Catalogs=] and usage control is expressed as ODRL [=Policies=].
+1. How [=Datasets=] are advertised via [=Catalogs=] (reusing terminology from [[?vocab-dcat-3]] and usage control is expressed as [=Policies=] (reusing terminology from [[?odrl-model]] vocabulary).
 2. How [=Agreements=] that govern data usage are syntactically expressed and electronically negotiated.
 3. How [=Datasets=] are accessed using [=Transfer Process Protocols=].
 

--- a/specifications/model/model.md
+++ b/specifications/model/model.md
@@ -46,14 +46,14 @@ The diagram below depicts the relationships between [=Participant Agent=] types:
 
 ![](figures/m.participant.entities.png "Class Diagram Participant Agent")
 
-- A [=Catalog Service=] is a [=Participant Agent=] that makes a DCAT [=Catalog=] available to other [=Participants=].
-- A [=Catalog=] contains one or more [=Datasets=], which are DCAT [=Datasets=]. A [=Catalog=] also contains *
-  *_at least one_** DCAT [=Data Service=] that references a [=Connector=] where [=Datasets=] may be obtained.
-- A [=Dataset=] has **_at least one_** [=Offer=], which is an ODRL [=Offer=] describing the [=Usage Policy=] associated
+- A [=Catalog Service=] is a [=Participant Agent=] that makes a [=Catalog=] available to other [=Participants=].
+- A [=Catalog=] contains one or more [=Datasets=], which are [=Datasets=]. A [=Catalog=] also contains 
+  **_at least one_** [=Data Service=] that references a [=Connector=] where [=Datasets=] may be obtained.
+- A [=Dataset=] has **_at least one_** [=Offer=] describing the [=Usage Policy=] associated
   with the [=Dataset=].
 - A [=Connector=] is a [=Participant Agent=] that performs [=Contract Negotiation=] and [=Transfer Process=] operations
-  with another [=Connector=]. An outcome of a [=Contract Negotiation=] may be the production of an [=Agreement=], which
-  is an ODRL [=Agreement=] defining the [=Usage Policy=] agreed to for a [=Dataset=].
+  with another [=Connector=]. An outcome of a [=Contract Negotiation=] may be the production of an [=Agreement=]
+  defining the [=Usage Policy=] agreed to for a [=Dataset=].
 
 ## Classes
 
@@ -64,7 +64,7 @@ elements of the model, i.e., those that are represented in protocol message flow
 
 **_Note 1:_**
 The classes and definitions used in the Dataspace Protocol are reused from different standards and specifications as
-much as possible, in particular, DCAT [[vocab-dcat-3]] and ODRL [[odrl-model]]. As, however, the external definitions
+much as possible, in particular, DCAT [[?vocab-dcat-3]] and ODRL [[?odrl-model]]. As, however, the external definitions
 allow different interpretations or provide more attributes than required, the Dataspace Protocol is leveraging
 _profiles_ of the original definitions rather than the complete original expressiveness. A _profile_ in this sense is a
 restriction or subset of an external definition, enforcing that every occurrence of an externally defined class is
@@ -74,36 +74,36 @@ types of the Dataspace Protocol.
 
 ### Catalog
 
-A [=Catalog=] is a DCAT [=Catalog=] with the following attributes:
+A [=Catalog=] has the following attributes:
 
 - 0..N [=Datasets=]. Since a [=Catalog=] may be dynamically generated for a request based on the
   requesting [=Participant=]'s credentials it is possible for it to contain 0 matching [=Datasets=].
-- 1..N DCAT [=Data Service=] that references a [=Connector=] where [=Datasets=] may be obtained. 
+- 1..N [=Data Services=] that references a [=Connector=] where [=Datasets=] may be obtained. 
 
 ### Dataset
 
 A [=Dataset=] has the following attributes:
 
-- 1..N `hasPolicy` attributes that contain an ODRL [=Offer=] defining the [=Usage Policy=] associated with
-  the [=Dataset=]. *
-  *_Offers must NOT contain any target attributes. The target of an [=Offer=] is the associated [=Dataset=]._**
-- 1..N DCAT `Distributions`. Each must have at least one `DataService` which specifies where the
+- 1..N `hasPolicy` attributes that contain an [=Offer=] defining the [=Usage Policy=] associated with
+  the [=Dataset=]. 
+  **_Offers must NOT contain any target attributes. The target of an [=Offer=] is the associated [=Dataset=]._**
+- 1..N `Distributions`. Each must have at least one `DataService` which specifies where the
   distribution
   is obtained. Specifically, a `DataService` specifies the endpoint for initiating a [=Contract Negotiation=]
   and [=Transfer Process=].
 
 ### Offer
 
-An [=Offer=] is an ODRL [=Offer=] with the following attributes:
+An [=Offer=] has the following attributes:
 
-- An ODRL `uid` is represented as an "@id" that is a unique identifier.
+- An `@id` that is a unique identifier.
 - The [=Offer=] must be unique to a [=Dataset=] since the target of the [=Offer=] is derived from its enclosing context.
 - The value of the `target` attribute is the dataset id. Except if the [Offer] is used in an enclosing [=Catalog=]
   or [=Dataset=], then the there must not be any `target` attribute set.
 
 ### Agreement
 
-An [=Agreement=] is an ODRL [=Agreement=] with the following attributes:
+An [=Agreement=] has the following attributes:
 
 - The [=Agreement=] class must include one `target` attribute that is the identifier of the [=Dataset=]
   the [=Agreement=] is associated with. An [=Agreement=] is therefore associated with **EXACTLY ONE** [=Dataset=].

--- a/specifications/negotiation/contract.negotiation.protocol.md
+++ b/specifications/negotiation/contract.negotiation.protocol.md
@@ -73,7 +73,7 @@ a [Contract Offer Message](#contract-offer-message) sent by a [=Provider=].
 - The `callbackAddress` is a URL indicating where messages to the [=Consumer=] should be sent in asynchronous settings.
   If the address is not understood, the [=Provider=] MUST return an UNRECOVERABLE error.
 - Different to a [=Catalog=] or [=Dataset=], the [=Offer=] inside
-  a [Contract Request Message](#contract-request-message) must have an `target` attribute. However, it's contained
+  a [Contract Request Message](#contract-request-message) must have a `target` attribute. However, it's contained
   Rules must not have any `target` attributes to prevent inconsistencies with
   the [ODRL inferencing rules for compact policies](https://www.w3.org/TR/odrl-model/#composition-compact).
 
@@ -96,7 +96,7 @@ a [Contract Request Message](#contract-request-message) sent by a [=Consumer=].
   appropriate `consumerPid`.
 - The [=Dataset=] id is not required but can be included when the [=Provider=] initiates a CN.
 - Different to a [=Dataset=],
-  the Offer inside a ContractOfferMessage must have an `target` attribute. However, it's contained Rules must not
+  the Offer inside a ContractOfferMessage must have a `target` attribute. However, its contained Rules must not
   have any `target` attributes to prevent inconsistencies with
   the [ODRL inferencing rules for compact policies](https://www.w3.org/TR/odrl-model/#composition-compact).
 

--- a/specifications/negotiation/contract.negotiation.protocol.md
+++ b/specifications/negotiation/contract.negotiation.protocol.md
@@ -47,7 +47,7 @@ as abstract message types.
 - Concrete wire formats are defined by the protocol binding, e.g., [Contract Negotiation HTTPS Binding](#contract-negotiation-https-binding).
 - All [=Policy=] types ([=Offer=], [=Agreement=]) must contain an unique identifier in the form of a URI. GUIDs can also
   be used in the form of URNs, for instance following the pattern <urn:uuid:{GUID}>.
-- An ODRL [=Agreement=] must have a target property containing the [=Dataset=] id.
+- An [=Agreement=] must have a `target` property containing the [=Dataset=] id.
 
 ### Contract Request Message
 
@@ -73,8 +73,8 @@ a [Contract Offer Message](#contract-offer-message) sent by a [=Provider=].
 - The `callbackAddress` is a URL indicating where messages to the [=Consumer=] should be sent in asynchronous settings.
   If the address is not understood, the [=Provider=] MUST return an UNRECOVERABLE error.
 - Different to a [=Catalog=] or [=Dataset=], the [=Offer=] inside
-  a [Contract Request Message](#contract-request-message) must have an `odrl:target` attribute. However, it's contained
-  Rules must not have any `odrl:target` attributes to prevent inconsistencies with
+  a [Contract Request Message](#contract-request-message) must have an `target` attribute. However, it's contained
+  Rules must not have any `target` attributes to prevent inconsistencies with
   the [ODRL inferencing rules for compact policies](https://www.w3.org/TR/odrl-model/#composition-compact).
 
 ### Contract Offer Message
@@ -96,8 +96,8 @@ a [Contract Request Message](#contract-request-message) sent by a [=Consumer=].
   appropriate `consumerPid`.
 - The [=Dataset=] id is not required but can be included when the [=Provider=] initiates a CN.
 - Different to a [=Dataset=],
-  the Offer inside a ContractOfferMessage must have an `odrl:target` attribute. However, it's contained Rules must not
-  have any `odrl:target` attributes to prevent inconsistencies with
+  the Offer inside a ContractOfferMessage must have an `target` attribute. However, it's contained Rules must not
+  have any `target` attributes to prevent inconsistencies with
   the [ODRL inferencing rules for compact policies](https://www.w3.org/TR/odrl-model/#composition-compact).
 
 ### Contract Agreement Message
@@ -115,14 +115,14 @@ The Contract Agreement Message is sent by a [=Provider=] when it agrees to a con
 complete [=Agreement=].
 
 - The message must contain a `consumerPid` and a `providerPid`.
-- The message must contain an ODRL [=Agreement=].
+- The message must contain an [=Agreement=].
 - An [=Agreement=] must contain a `timestamp` property defined as
   an [XSD DateTime](https://www.w3schools.com/XML/schema_dtypes_date.asp) type.
 - An [=Agreement=] must contain an `assigner` and `assignee`. The contents of these properties are a dataspace-specific
   unique identifier of the [=Agreement=] parties. Note that these identifiers are not necessarily the same as the
   identifiers of the [=Participant Agents=] negotiating the contract (
   e.g., [=Connectors=]).
-- An [=Agreement=] must contain a `odrl:target` property. None of its Rules, however, must have any `odrl:target`
+- An [=Agreement=] must contain a `target` property. None of its Rules, however, must have any `target`
   attributes to prevent inconsistencies with
   the [ODRL inferencing rules for compact policies](https://www.w3.org/TR/odrl-model/#composition-compact).
 


### PR DESCRIPTION
## What this PR changes/adds

This PR clarifies the (lack of) dependence of the DSP on the DCAT and ODRL vocabularies.

## Why it does that

Since the json-schemas are the sole normative source for message structure, the external pointers are no longer providing any benefit.

## Linked Issue(s)

Closes #78

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._