### PR TITLE
feat: change remote context uris

### DIFF
--- a/artifacts/src/main/resources/catalog/example/catalog-error.json
+++ b/artifacts/src/main/resources/catalog/example/catalog-error.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "CatalogError",
   "code": "123-A",

--- a/artifacts/src/main/resources/catalog/example/catalog-request-message.json
+++ b/artifacts/src/main/resources/catalog/example/catalog-request-message.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "CatalogRequestMessage",
   "filter": []

--- a/artifacts/src/main/resources/catalog/example/catalog.json
+++ b/artifacts/src/main/resources/catalog/example/catalog.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@id": "urn:uuid:3afeadd8-ed2d-569e-d634-8394a8836d57",
   "@type": "Catalog",

--- a/artifacts/src/main/resources/catalog/example/dataset-request-message.json
+++ b/artifacts/src/main/resources/catalog/example/dataset-request-message.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "DatasetRequestMessage",
   "dataset": "urn:uuid:3afeadd8-ed2d-569e-d634-8394a8836d57"

--- a/artifacts/src/main/resources/catalog/example/dataset.json
+++ b/artifacts/src/main/resources/catalog/example/dataset.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@id": "urn:uuid:3afeadd8-ed2d-569e-d634-8394a8836d57",
   "@type": "Dataset",

--- a/artifacts/src/main/resources/catalog/example/nested-catalog.json
+++ b/artifacts/src/main/resources/catalog/example/nested-catalog.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@id": "urn:uuid:3afeadd8-ed2d-569e-d634-8394a8836d57",
   "@type": "Catalog",

--- a/artifacts/src/main/resources/common/context-schema.json
+++ b/artifacts/src/main/resources/common/context-schema.json
@@ -18,7 +18,7 @@
         }
       },
       "contains": {
-        "const": "https://w3id.org/dspace/2025/1/context.json"
+        "const": "https://w3id.org/dspace/2025/1/context.jsonld"
       }
     }
   }

--- a/artifacts/src/main/resources/context/dspace.jsonld
+++ b/artifacts/src/main/resources/context/dspace.jsonld
@@ -43,7 +43,7 @@
       "@context": {
         "@version": 1.1,
         "@protected": true,
-        "@import": "http://www.w3.org/dspace-odrl/odrl.jsonld",
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
         "@propagate": true,
         "callbackAddress": "dspace:callbackAddress",
         "providerPid": {
@@ -65,7 +65,7 @@
       "@context": {
         "@version": 1.1,
         "@protected": true,
-        "@import": "http://www.w3.org/dspace-odrl/odrl.jsonld",
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
         "@propagate": true,
         "callbackAddress": "dspace:callbackAddress",
         "providerPid": {
@@ -87,7 +87,7 @@
       "@context": {
         "@version": 1.1,
         "@protected": true,
-        "@import": "http://www.w3.org/dspace-odrl/odrl.jsonld",
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
         "@propagate": true,
         "providerPid": {
           "@type": "@id",
@@ -392,7 +392,7 @@
       "@context": {
         "@version": 1.1,
         "@protected": true,
-        "@import": "http://www.w3.org/dspace-odrl/odrl.jsonld",
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
         "@propagate": true,
         "distribution": {
           "@id": "dcat:distribution",

--- a/artifacts/src/main/resources/negotiation/example/contract-agreement-message-full.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-agreement-message-full.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "ContractAgreementMessage",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/negotiation/example/contract-agreement-message.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-agreement-message.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "ContractAgreementMessage",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/negotiation/example/contract-agreement-verification-message.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-agreement-verification-message.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "ContractAgreementVerificationMessage",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/negotiation/example/contract-negotiation-error.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-negotiation-error.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "ContractNegotiationError",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/negotiation/example/contract-negotiation-event-message.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-negotiation-event-message.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "ContractNegotiationEventMessage",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/negotiation/example/contract-negotiation-termination-message.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-negotiation-termination-message.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "ContractNegotiationTerminationMessage",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/negotiation/example/contract-negotiation.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-negotiation.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "ContractNegotiation",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/negotiation/example/contract-offer-message.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-offer-message.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "ContractOfferMessage",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/negotiation/example/contract-offer-message_initial.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-offer-message_initial.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "ContractOfferMessage",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/negotiation/example/contract-request-message.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-request-message.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "ContractRequestMessage",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/negotiation/example/contract-request-message_initial.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-request-message_initial.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "ContractRequestMessage",
   "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",

--- a/artifacts/src/main/resources/transfer/example/transfer-completion-message.json
+++ b/artifacts/src/main/resources/transfer/example/transfer-completion-message.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "TransferCompletionMessage",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/transfer/example/transfer-error.json
+++ b/artifacts/src/main/resources/transfer/example/transfer-error.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "TransferError",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/transfer/example/transfer-process.json
+++ b/artifacts/src/main/resources/transfer/example/transfer-process.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "TransferProcess",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/transfer/example/transfer-request-message.json
+++ b/artifacts/src/main/resources/transfer/example/transfer-request-message.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "TransferRequestMessage",
   "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",

--- a/artifacts/src/main/resources/transfer/example/transfer-start-message.json
+++ b/artifacts/src/main/resources/transfer/example/transfer-start-message.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "TransferStartMessage",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/main/resources/transfer/example/transfer-suspension-message.json
+++ b/artifacts/src/main/resources/transfer/example/transfer-suspension-message.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"],
+    "https://w3id.org/dspace/2025/1/context.jsonld"],
   "@type": "TransferSuspensionMessage",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
   "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",

--- a/artifacts/src/main/resources/transfer/example/transfer-termination-message.json
+++ b/artifacts/src/main/resources/transfer/example/transfer-termination-message.json
@@ -1,6 +1,6 @@
 {
   "@context": [
-    "https://w3id.org/dspace/2025/1/context.json"
+    "https://w3id.org/dspace/2025/1/context.jsonld"
   ],
   "@type": "TransferTerminationMessage",
   "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/test/java/org/eclipse/dsp/DspConstants.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/DspConstants.java
@@ -19,9 +19,9 @@ package org.eclipse.dsp;
  */
 public interface DspConstants {
 
-    String DSP_CONTEXT = "https://w3id.org/dspace/2025/1/context.json";
+    String DSP_CONTEXT = "https://w3id.org/dspace/2025/1/context.jsonld";
+    String ODRL_PROFILE_CONTEXT = "https://w3id.org/dspace/2025/1/odrl-profile.jsonld";
     String DSP_PREFIX = "https://w3id.org/dspace/2025/1/";
 
-    String ODRL_CONTEXT = "http://www.w3.org/dspace-odrl/odrl.jsonld";
 
 }

--- a/artifacts/src/test/java/org/eclipse/dsp/context/fixtures/AbstractJsonLdTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/context/fixtures/AbstractJsonLdTest.java
@@ -41,7 +41,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dsp.DspConstants.DSP_CONTEXT;
 import static org.eclipse.dsp.DspConstants.DSP_PREFIX;
-import static org.eclipse.dsp.DspConstants.ODRL_CONTEXT;
+import static org.eclipse.dsp.DspConstants.ODRL_PROFILE_CONTEXT;
 
 /**
  * Base class for Json-Ld expansion and compaction tests.
@@ -83,7 +83,7 @@ public abstract class AbstractJsonLdTest {
             var dspaceContext = mapper.readValue(dspaceStream, JsonObject.class);
             @SuppressWarnings("DataFlowIssue")
             Map<String, Document> cache = Map.of(DSP_CONTEXT, JsonDocument.of(dspaceContext),
-                    ODRL_CONTEXT, JsonDocument.of(odrlStream)
+                    ODRL_PROFILE_CONTEXT, JsonDocument.of(odrlStream)
             );
             var documentLoader = new LocalDocumentLoader(cache);
             compactionContext = mapper.readValue(CONTEXT_REFERENCE, JsonStructure.class);

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/catalog/CatalogErrorSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/catalog/CatalogErrorSchemaTest.java
@@ -68,7 +68,7 @@ public class CatalogErrorSchemaTest extends AbstractSchemaTest {
     private static final String VALID_NO_CODE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "CatalogError"
             }""";
@@ -76,7 +76,7 @@ public class CatalogErrorSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_CODE_TYPE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "CatalogError",
               "code": 123,
@@ -88,7 +88,7 @@ public class CatalogErrorSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_REASON = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "CatalogError",
               "code": "123-A",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/catalog/CatalogSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/catalog/CatalogSchemaTest.java
@@ -40,7 +40,7 @@ public class CatalogSchemaTest extends AbstractSchemaTest {
     private static final String MINIMAL_CATALOG = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@id": "urn:uuid:3afeadd8-ed2d-569e-d634-8394a8836d57",
               "@type": "Catalog",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/catalog/DatasetSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/catalog/DatasetSchemaTest.java
@@ -36,7 +36,7 @@ public class DatasetSchemaTest extends AbstractSchemaTest {
     private static final String DATASET = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@id": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
               "hasPolicy": [

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/catalog/InvalidCatalogSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/catalog/InvalidCatalogSchemaTest.java
@@ -86,7 +86,7 @@ public class InvalidCatalogSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_CATALOG_NO_ID = format("""
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "Catalog",
               "participantId": "urn:example:DataProviderA",
@@ -104,7 +104,7 @@ public class InvalidCatalogSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_CATALOG_NO_PARTICIPANT_ID = format("""
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@id": "urn:uuid:3afeadd8-ed2d-569e-d634-8394a8836d57",
               "@type": "Catalog",
@@ -122,7 +122,7 @@ public class InvalidCatalogSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_NO_SERVICE_ID = format("""
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@id": "urn:uuid:3afeadd8-ed2d-569e-d634-8394a8836d57",
               "@type": "Catalog",
@@ -140,7 +140,7 @@ public class InvalidCatalogSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_NO_SERVICE_ENDPOINT = format("""
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@id": "urn:uuid:3afeadd8-ed2d-569e-d634-8394a8836d57",
               "@type": "Catalog",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/common/CommonSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/common/CommonSchemaTest.java
@@ -26,13 +26,13 @@ public class CommonSchemaTest extends AbstractSchemaTest {
     @Test
     void verifyContext() {
         var baseInput = """
-                ["https://w3id.org/dspace/2025/1/context.json"]
+                ["https://w3id.org/dspace/2025/1/context.jsonld"]
                 """;
         assertThat(schema.validate(baseInput, JSON)).isEmpty();
 
         var multiValueInput = """
                 [
-                    "https://w3id.org/dspace/2025/1/context.json",
+                    "https://w3id.org/dspace/2025/1/context.jsonld",
                     "https://test.com/context.json"
                 ]
                 """;

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/ContractNegotiationErrorSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/ContractNegotiationErrorSchemaTest.java
@@ -44,7 +44,7 @@ public class ContractNegotiationErrorSchemaTest extends AbstractSchemaTest {
     private static final String MINIMAL_ERROR = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractNegotiationError",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/ContractNegotiationEventMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/ContractNegotiationEventMessageSchemaTest.java
@@ -41,7 +41,7 @@ public class ContractNegotiationEventMessageSchemaTest extends AbstractSchemaTes
     private static final String ACCEPTED_EVENT_TYPE = """
              {
                "@context": [
-                 "https://w3id.org/dspace/2025/1/context.json"
+                 "https://w3id.org/dspace/2025/1/context.jsonld"
                ],
                "@type": "ContractNegotiationEventMessage",
                "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -53,7 +53,7 @@ public class ContractNegotiationEventMessageSchemaTest extends AbstractSchemaTes
     private static final String FINALIZED_EVENT_TYPE = """
              {
                "@context": [
-                 "https://w3id.org/dspace/2025/1/context.json"
+                 "https://w3id.org/dspace/2025/1/context.jsonld"
                ],
                "@type": "ContractNegotiationEventMessage",
                "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/ContractNegotiationTerminationMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/ContractNegotiationTerminationMessageSchemaTest.java
@@ -44,7 +44,7 @@ public class ContractNegotiationTerminationMessageSchemaTest extends AbstractSch
     private static final String MINIMAL_MESSAGE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractNegotiationTerminationMessage",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/ContractRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/ContractRequestMessageSchemaTest.java
@@ -51,7 +51,7 @@ public class ContractRequestMessageSchemaTest extends AbstractSchemaTest {
     private static final String REQUEST_ID = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "ContractRequestMessage",
                 "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -66,7 +66,7 @@ public class ContractRequestMessageSchemaTest extends AbstractSchemaTest {
     private static final String REQUEST_INITIAL_ID = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "ContractRequestMessage",
                 "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractAgreementMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractAgreementMessageSchemaTest.java
@@ -75,7 +75,7 @@ public class InvalidContractAgreementMessageSchemaTest extends AbstractSchemaTes
     private static final String INVALID_NO_TYPE = format("""
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -87,7 +87,7 @@ public class InvalidContractAgreementMessageSchemaTest extends AbstractSchemaTes
     private static final String INVALID_NO_PROVIDER_ID = format("""
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractAgreementMessage",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -99,7 +99,7 @@ public class InvalidContractAgreementMessageSchemaTest extends AbstractSchemaTes
     private static final String INVALID_NO_CONSUMER_ID = format("""
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractAgreementMessage",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -111,7 +111,7 @@ public class InvalidContractAgreementMessageSchemaTest extends AbstractSchemaTes
     private static final String INVALID_NO_CALLBACK = format("""
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractAgreementMessage",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -123,7 +123,7 @@ public class InvalidContractAgreementMessageSchemaTest extends AbstractSchemaTes
     private static final String NO_AGREEMENT = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractAgreementMessage",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractAgreementVerificationMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractAgreementVerificationMessageSchemaTest.java
@@ -47,7 +47,7 @@ public class InvalidContractAgreementVerificationMessageSchemaTest extends Abstr
     private static final String INVALID_MESSAGE_NO_TYPE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -57,7 +57,7 @@ public class InvalidContractAgreementVerificationMessageSchemaTest extends Abstr
     private static final String INVALID_MESSAGE_NO_PROVIDER_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractAgreementVerificationMessage",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -67,7 +67,7 @@ public class InvalidContractAgreementVerificationMessageSchemaTest extends Abstr
     private static final String INVALID_MESSAGE_NO_CONSUMER_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractAgreementVerificationMessage",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab"

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractNegotiationErrorSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractNegotiationErrorSchemaTest.java
@@ -47,7 +47,7 @@ public class InvalidContractNegotiationErrorSchemaTest extends AbstractSchemaTes
     private static final String INVALID_MESSAGE_NO_TYPE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -57,7 +57,7 @@ public class InvalidContractNegotiationErrorSchemaTest extends AbstractSchemaTes
     private static final String INVALID_MESSAGE_NO_PROVIDER_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractNegotiationError",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -67,7 +67,7 @@ public class InvalidContractNegotiationErrorSchemaTest extends AbstractSchemaTes
     private static final String INVALID_MESSAGE_NO_CONSUMER_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractNegotiationError",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab"

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractNegotiationEventMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractNegotiationEventMessageSchemaTest.java
@@ -50,7 +50,7 @@ public class InvalidContractNegotiationEventMessageSchemaTest extends AbstractSc
     private static final String INVALID_MESSAGE_NO_TYPE = """
              {
                "@context": [
-                 "https://w3id.org/dspace/2025/1/context.json"
+                 "https://w3id.org/dspace/2025/1/context.jsonld"
                ],
                "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
                "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -61,7 +61,7 @@ public class InvalidContractNegotiationEventMessageSchemaTest extends AbstractSc
     private static final String INVALID_MESSAGE_NO_PROVIDER_ID = """
              {
                "@context": [
-                 "https://w3id.org/dspace/2025/1/context.json"
+                 "https://w3id.org/dspace/2025/1/context.jsonld"
                ],
                "@type": "ContractNegotiationEventMessage",
                "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -72,7 +72,7 @@ public class InvalidContractNegotiationEventMessageSchemaTest extends AbstractSc
     private static final String INVALID_MESSAGE_NO_CONSUMER_ID = """
              {
                "@context": [
-                 "https://w3id.org/dspace/2025/1/context.json"
+                 "https://w3id.org/dspace/2025/1/context.jsonld"
                ],
                "@type": "ContractNegotiationEventMessage",
                "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -83,7 +83,7 @@ public class InvalidContractNegotiationEventMessageSchemaTest extends AbstractSc
     private static final String INVALID_MESSAGE_NO_EVENT_TYPE = """
              {
                "@context": [
-                 "https://w3id.org/dspace/2025/1/context.json"
+                 "https://w3id.org/dspace/2025/1/context.jsonld"
                ],
                "@type": "ContractNegotiationEventMessage",
                "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -94,7 +94,7 @@ public class InvalidContractNegotiationEventMessageSchemaTest extends AbstractSc
     private static final String INVALID_MESSAGE_EVENT_TYPE = """
              {
                "@context": [
-                 "https://w3id.org/dspace/2025/1/context.json"
+                 "https://w3id.org/dspace/2025/1/context.jsonld"
                ],
                "@type": "ContractNegotiationEventMessage",
                "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractNegotiationSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractNegotiationSchemaTest.java
@@ -50,7 +50,7 @@ public class InvalidContractNegotiationSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_NO_TYPE = """
              {
                "@context": [
-                 "https://w3id.org/dspace/2025/1/context.json"
+                 "https://w3id.org/dspace/2025/1/context.jsonld"
                ],
                "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
                "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -61,7 +61,7 @@ public class InvalidContractNegotiationSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_NO_PROVIDER_ID = """
              {
                "@context": [
-                 "https://w3id.org/dspace/2025/1/context.json"
+                 "https://w3id.org/dspace/2025/1/context.jsonld"
                ],
                "@type": "ContractNegotiation",
                "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -72,7 +72,7 @@ public class InvalidContractNegotiationSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_NO_CONSUMER_ID = """
              {
                "@context": [
-                 "https://w3id.org/dspace/2025/1/context.json"
+                 "https://w3id.org/dspace/2025/1/context.jsonld"
                ],
                "@type": "ContractNegotiation",
                "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -83,7 +83,7 @@ public class InvalidContractNegotiationSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_NO_STATE = """
              {
                "@context": [
-                 "https://w3id.org/dspace/2025/1/context.json"
+                 "https://w3id.org/dspace/2025/1/context.jsonld"
                ],
                "@type": "ContractNegotiation",
                "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -94,7 +94,7 @@ public class InvalidContractNegotiationSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_STATE = """
              {
                "@context": [
-                 "https://w3id.org/dspace/2025/1/context.json"
+                 "https://w3id.org/dspace/2025/1/context.jsonld"
                ],
                "@type": "ContractNegotiation",
                "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractNegotiationTerminationMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractNegotiationTerminationMessageSchemaTest.java
@@ -51,7 +51,7 @@ public class InvalidContractNegotiationTerminationMessageSchemaTest extends Abst
     private static final String MESSAGE_NO_TYPE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "consumerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -65,7 +65,7 @@ public class InvalidContractNegotiationTerminationMessageSchemaTest extends Abst
     private static final String MESSAGE_NO_CONSUMER_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractNegotiationTerminationMessage",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -79,7 +79,7 @@ public class InvalidContractNegotiationTerminationMessageSchemaTest extends Abst
     private static final String MESSAGE_NO_PROVIDER_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractNegotiationTerminationMessage",
               "consumerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractOfferMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractOfferMessageSchemaTest.java
@@ -37,7 +37,7 @@ public class InvalidContractOfferMessageSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_NO_TARGET = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractOfferMessage",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -58,7 +58,7 @@ public class InvalidContractOfferMessageSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_NO_CALLBACK = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "ContractOfferMessage",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractRequestMessageSchemaTest.java
@@ -41,7 +41,7 @@ public class InvalidContractRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_REQUEST_NO_OFFER = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "ContractRequestMessage",
                 "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -53,7 +53,7 @@ public class InvalidContractRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_REQUEST_NO_ID = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "ContractRequestMessage",
                 "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -67,7 +67,7 @@ public class InvalidContractRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_REQUEST_NO_CONSUMER_ID = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "ContractRequestMessage",
                 "offer": {
@@ -80,7 +80,7 @@ public class InvalidContractRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_REQUEST_NO_CALLBACK = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "ContractRequestMessage",
                 "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -93,7 +93,7 @@ public class InvalidContractRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_REQUEST_NO_TYPE = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
                 "offer": {

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferCompletionMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferCompletionMessageSchemaTest.java
@@ -47,7 +47,7 @@ public class InvalidTransferCompletionMessageSchemaTest extends AbstractSchemaTe
     private static final String INVALID_MESSAGE_NO_TYPE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -57,7 +57,7 @@ public class InvalidTransferCompletionMessageSchemaTest extends AbstractSchemaTe
     private static final String INVALID_MESSAGE_NO_PROVIDER_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferCompletionMessage",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -67,7 +67,7 @@ public class InvalidTransferCompletionMessageSchemaTest extends AbstractSchemaTe
     private static final String INVALID_MESSAGE_NO_CONSUMER_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferCompletionMessage",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab"

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferErrorSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferErrorSchemaTest.java
@@ -47,7 +47,7 @@ public class InvalidTransferErrorSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_NO_TYPE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -57,7 +57,7 @@ public class InvalidTransferErrorSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_NO_PROVIDER_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferError",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -67,7 +67,7 @@ public class InvalidTransferErrorSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_NO_CONSUMER_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferError",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab"

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferProcessSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferProcessSchemaTest.java
@@ -50,7 +50,7 @@ public class InvalidTransferProcessSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_NO_TYPE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -61,7 +61,7 @@ public class InvalidTransferProcessSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_NO_PROVIDER_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferProcess",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -72,7 +72,7 @@ public class InvalidTransferProcessSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_NO_CONSUMER_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferProcess",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -83,7 +83,7 @@ public class InvalidTransferProcessSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_NO_STATE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferProcess",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
@@ -94,7 +94,7 @@ public class InvalidTransferProcessSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_MESSAGE_STATE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferProcess",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferRequestMessageSchemaTest.java
@@ -55,7 +55,7 @@ public class InvalidTransferRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_REQUEST_NO_TYPE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
               "agreementId": "urn:uuid:e8dc8655-44c2-46ef-b701-4cffdc2faa44",
@@ -67,7 +67,7 @@ public class InvalidTransferRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_REQUEST_NO_CONSUMER_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferRequestMessage",
               "agreementId": "urn:uuid:e8dc8655-44c2-46ef-b701-4cffdc2faa44",
@@ -79,7 +79,7 @@ public class InvalidTransferRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_REQUEST_NO_AGREEMENT_ID = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferRequestMessage",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -91,7 +91,7 @@ public class InvalidTransferRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_REQUEST_NO_FORMAT = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferRequestMessage",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -103,7 +103,7 @@ public class InvalidTransferRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_REQUEST_NO_CALLBACK = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferRequestMessage",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -115,7 +115,7 @@ public class InvalidTransferRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_NO_DA_TYPE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferRequestMessage",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -132,7 +132,7 @@ public class InvalidTransferRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_NO_DA_ENDPOINT_TYPE = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferRequestMessage",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
@@ -149,7 +149,7 @@ public class InvalidTransferRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_NO_DA_ENDPOINT = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferRequestMessage",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferStartMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferStartMessageSchemaTest.java
@@ -38,7 +38,7 @@ public class InvalidTransferStartMessageSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_NO_TYPE = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
                 "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -47,7 +47,7 @@ public class InvalidTransferStartMessageSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_NO_PROVIDER_ID = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "TransferStartMessage",
                 "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -56,7 +56,7 @@ public class InvalidTransferStartMessageSchemaTest extends AbstractSchemaTest {
     private static final String INVALID_NO_CONSUMER_ID = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "TransferStartMessage",
                 "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab"

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferSuspensionMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferSuspensionMessageSchemaTest.java
@@ -38,7 +38,7 @@ public class InvalidTransferSuspensionMessageSchemaTest extends AbstractSchemaTe
     private static final String INVALID_NO_TYPE = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
                 "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -47,7 +47,7 @@ public class InvalidTransferSuspensionMessageSchemaTest extends AbstractSchemaTe
     private static final String INVALID_NO_PROVIDER_ID = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "TransferSuspensionMessage",
                 "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -56,7 +56,7 @@ public class InvalidTransferSuspensionMessageSchemaTest extends AbstractSchemaTe
     private static final String INVALID_NO_CONSUMER_ID = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "TransferSuspensionMessage",
                 "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab"

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferTerminationMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferTerminationMessageSchemaTest.java
@@ -38,7 +38,7 @@ public class InvalidTransferTerminationMessageSchemaTest extends AbstractSchemaT
     private static final String INVALID_NO_TYPE = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
                 "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -47,7 +47,7 @@ public class InvalidTransferTerminationMessageSchemaTest extends AbstractSchemaT
     private static final String INVALID_NO_PROVIDER_ID = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "TransferTerminationMessage",
                 "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833"
@@ -56,7 +56,7 @@ public class InvalidTransferTerminationMessageSchemaTest extends AbstractSchemaT
     private static final String INVALID_NO_CONSUMER_ID = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "TransferTerminationMessage",
                 "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab"

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/TransferErrorSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/TransferErrorSchemaTest.java
@@ -44,7 +44,7 @@ public class TransferErrorSchemaTest extends AbstractSchemaTest {
     private static final String MINIMAL_ERROR = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferError",
               "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/TransferRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/TransferRequestMessageSchemaTest.java
@@ -44,7 +44,7 @@ public class TransferRequestMessageSchemaTest extends AbstractSchemaTest {
     private static final String MINIMAL_REQUEST = """
             {
               "@context": [
-                "https://w3id.org/dspace/2025/1/context.json"
+                "https://w3id.org/dspace/2025/1/context.jsonld"
               ],
               "@type": "TransferRequestMessage",
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/TransferStartMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/TransferStartMessageSchemaTest.java
@@ -44,7 +44,7 @@ public class TransferStartMessageSchemaTest extends AbstractSchemaTest {
     private static final String MINIMAL_REQUEST = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "TransferStartMessage",
                 "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/TransferSuspensionMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/TransferSuspensionMessageSchemaTest.java
@@ -44,7 +44,7 @@ public class TransferSuspensionMessageSchemaTest extends AbstractSchemaTest {
     private static final String MINIMAL_REQUEST = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "TransferSuspensionMessage",
                 "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/TransferTerminationMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/TransferTerminationMessageSchemaTest.java
@@ -44,7 +44,7 @@ public class TransferTerminationMessageSchemaTest extends AbstractSchemaTest {
     private static final String MINIMAL_REQUEST = """
             {
                 "@context": [
-                  "https://w3id.org/dspace/2025/1/context.json"
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
                 ],
                 "@type": "TransferTerminationMessage",
                 "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",

--- a/specifications/catalog/catalog.binding.https.md
+++ b/specifications/catalog/catalog.binding.https.md
@@ -102,7 +102,7 @@ The following request sequence demonstrates pagination:
 Link: <https://provider.com/catalog?continuationToken=f59892315ac44de8ab4bdc9014502d52>; rel="next"
 
 {
-  "@context":  "https://w3id.org/dspace/2025/1/context.json",
+  "@context":  "https://w3id.org/dspace/2025/1/context.jsonld",
   "@type": "Catalog",
   ...
 }

--- a/specifications/catalog/message/diagram/catalog-error.puml
+++ b/specifications/catalog/message/diagram/catalog-error.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:CatalogError" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:CatalogError"
     dspace:code : String
     dspace:reason : Array

--- a/specifications/catalog/message/diagram/catalog-request-message.puml
+++ b/specifications/catalog/message/diagram/catalog-request-message.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:CatalogRequestMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : dspace:CatalogRequestMessage
     dspace:filter : Object
 }

--- a/specifications/catalog/message/diagram/catalog.puml
+++ b/specifications/catalog/message/diagram/catalog.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class dcat:Catalog {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dcat:Catalog"
     foaf:homepage : String
     dcat:theme : Array<String>

--- a/specifications/catalog/message/diagram/dataset-request-message.puml
+++ b/specifications/catalog/message/diagram/dataset-request-message.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:DatasetRequestMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : dspace:DatasetRequestMessage
     dspace:dataset : String
 }

--- a/specifications/catalog/message/diagram/dataset.puml
+++ b/specifications/catalog/message/diagram/dataset.puml
@@ -6,7 +6,7 @@
 hide empty description
 
 class dcat:Dataset {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dcat:Dataset",
     dcat:theme : Array<String>
     dcat:keyword : Array<String>

--- a/specifications/negotiation/message/diagram/contract-agreement-message.puml
+++ b/specifications/negotiation/message/diagram/contract-agreement-message.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:ContractAgreementMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:ContractAgreementMessage"
     dspace:providerPid : String
     dspace:consumerPid : String

--- a/specifications/negotiation/message/diagram/contract-agreement-verification-message.puml
+++ b/specifications/negotiation/message/diagram/contract-agreement-verification-message.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:ContractAgreementVerificationMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:ContractAgreementVerificationMessage"
     dspace:providerPid : String
     dspace:consumerPid : String

--- a/specifications/negotiation/message/diagram/contract-negotiation-error.puml
+++ b/specifications/negotiation/message/diagram/contract-negotiation-error.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:ContractNegotiationError" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:ContractNegotiationError"
     dspace:providerPid : String
     dspace:consumerPid : String

--- a/specifications/negotiation/message/diagram/contract-negotiation-event-message.puml
+++ b/specifications/negotiation/message/diagram/contract-negotiation-event-message.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:ContractNegotiationEventMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:ContractNegotiationEventMessage"
     dspace:providerPid : String
     dspace:consumerPid : String

--- a/specifications/negotiation/message/diagram/contract-negotiation-termination-message.puml
+++ b/specifications/negotiation/message/diagram/contract-negotiation-termination-message.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:ContractNegotiationTerminationMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:ContractNegotiationTerminationMessage"
     dspace:providerPid : String
     dspace:consumerPid : String

--- a/specifications/negotiation/message/diagram/contract-negotiation.puml
+++ b/specifications/negotiation/message/diagram/contract-negotiation.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:ContractNegotiation" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:ContractNegotiation"
     dspace:providerPid : String
     dspace:consumerPid : String

--- a/specifications/negotiation/message/diagram/contract-offer-message.puml
+++ b/specifications/negotiation/message/diagram/contract-offer-message.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:ContractOfferMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : dspace:ContractOfferMessage
     dspace:providerPid : String
     dspace:consumerPid : String

--- a/specifications/negotiation/message/diagram/contract-offer-message_initial.puml
+++ b/specifications/negotiation/message/diagram/contract-offer-message_initial.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:ContractOfferMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : dspace:ContractOfferMessage
     dspace:providerPid : String
     dspace:callbackAddress : String

--- a/specifications/negotiation/message/diagram/contract-request-message.puml
+++ b/specifications/negotiation/message/diagram/contract-request-message.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:ContractRequestMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : dspace:ContractRequestMessage
     dspace:providerPid : String
     dspace:consumerPid : String

--- a/specifications/negotiation/message/diagram/contract-request-message_initial.puml
+++ b/specifications/negotiation/message/diagram/contract-request-message_initial.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:ContractRequestMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : dspace:ContractRequestMessage
     dspace:consumerPid : String
     dspace:callbackAddress : String

--- a/specifications/transfer/message/diagram/transfer-completion-message.puml
+++ b/specifications/transfer/message/diagram/transfer-completion-message.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:TransferCompletionMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:TransferCompletionMessage"
     dspace:providerPid : String
     dspace:consumerPid : String

--- a/specifications/transfer/message/diagram/transfer-error.puml
+++ b/specifications/transfer/message/diagram/transfer-error.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:TransferError" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:TransferError"
     dspace:providerPid : String
     dspace:consumerPid : String

--- a/specifications/transfer/message/diagram/transfer-process.puml
+++ b/specifications/transfer/message/diagram/transfer-process.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:TransferProcess" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:TransferProcess"
     dspace:providerPid : String
     dspace:consumerPid : String

--- a/specifications/transfer/message/diagram/transfer-request-message.puml
+++ b/specifications/transfer/message/diagram/transfer-request-message.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:TransferRequestMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:TransferRequestMessage"
     dspace:consumerPid : String
     dspace:agreementId : String

--- a/specifications/transfer/message/diagram/transfer-start-message.puml
+++ b/specifications/transfer/message/diagram/transfer-start-message.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:TransferStartMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:TransferStartMessage"
     dspace:providerPid : String
     dspace:consumerPid : String

--- a/specifications/transfer/message/diagram/transfer-suspension-message.puml
+++ b/specifications/transfer/message/diagram/transfer-suspension-message.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:TransferSuspensionMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:TransferSuspensionMessage"
     dspace:providerPid : String
     dspace:consumerPid : String

--- a/specifications/transfer/message/diagram/transfer-termination-message.puml
+++ b/specifications/transfer/message/diagram/transfer-termination-message.puml
@@ -7,7 +7,7 @@ hide empty description
 
 
 class "dspace:TransferTerminationMessage" {
-    @context : "https://w3id.org/dspace/2025/1/context.json"
+    @context : "https://w3id.org/dspace/2025/1/context.jsonld"
     @type : "dspace:TransferTerminationMessage"
     dspace:providerPid : String
     dspace:consumerPid : String


### PR DESCRIPTION
## What this PR changes/adds

This PR edits the URIs for the DSP relevant JSON-LD context objects.

1. The URI for the ODRL profile context
  - today: `http://www.w3.org/dspace-odrl/odrl.jsonld`
  - discussed: `http://www.w3.org/dspace/2025/1/odrl-profile.jsonld`. This isn't possible because we don't control `w3.org` but only `w3id.org`. Thus closes #71
  - suggested: `https://w3id.org/dspace/2025/1/odrl-profile.jsonld` (PR to activate this referral is linked in the issue
2. The URI for the dspace context
  - today: `https://w3id.org/dspace/2025/1/context.json`
  - suggested: `https://w3id.org/dspace/2025/1/context.jsonld`. This is analogous to the odrl-profile-context and will lead to the context being served as `application/ld+json`

## Why it does that

Currently, none of the contexts resolve.

## Further notes

There's a corresponding PR open at w3id. https://github.com/perma-id/w3id.org/pull/4686
