### PR TITLE
refactor: improve readability of ToC and bindings

### DIFF
--- a/specifications/catalog/catalog.binding.https.md
+++ b/specifications/catalog/catalog.binding.https.md
@@ -24,11 +24,9 @@ a [Catalog Error](#error-catalog-error) in the response body.
 | https://provider.com/catalog/request      | `POST` | [[[#catalog-request-post]]] |
 | https://provider.com/catalog/datasets/:id | `GET`  | [[[#catalog-datasets-get]]] |
 
-### The `catalog/request` Endpoint (Provider-side)
+### Catalog Request Endpoint {#catalog-request-post}
 
-#### POST {#catalog-request-post}
-
-##### Request
+**Request**
 
 The [Catalog Request Message](#catalog-request-message) corresponds to `POST https://<base>/catalog/request`:
 
@@ -47,7 +45,7 @@ Authorization: ...</pre>
   expression or query to be executed as part of the [=Catalog=] request. If a filter expression is not supported by an
   implementation, it must return a HTTP 400 (Bad Request) response.
 
-##### Response
+**Response**
 
 If the request is successful, the [=Catalog Service=] must return an HTTP 200 (OK) with a response body containing
 a [Catalog](#ack-catalog).
@@ -57,11 +55,9 @@ a [Catalog](#ack-catalog).
     </pre>
 </aside>
 
-### The `catalog/datasets/:id` Endpoint (Provider-side)
+### Dataset Request Endpoint {#catalog-datasets-get}
 
-#### GET {#catalog-datasets-get}
-
-##### Request
+**Request**
 
 The [Dataset Request Message](#dataset-request-message) corresponds
 to `GET https://<base>/catalog/datasets/:id}`:
@@ -76,7 +72,7 @@ Authorization: ...</pre>
   contents of the `Authorization` header are detailed in
   the [[[#authorization]]].
 
-##### Response
+**Response**
 
 If the request is successful, the [=Catalog Service=] must return an HTTP 200 (OK) with a response body containing
 a [Dataset](#ack-dataset).

--- a/specifications/common/common.protocol.md
+++ b/specifications/common/common.protocol.md
@@ -15,7 +15,7 @@ type. This allows implementations to choose whether to process messages as plain
 interoperability between those approaches. Extensions that use JSON-LD are encouraged to provide similar contexts that
 facilitate this approach to interoperability.
 
-## Exposure of Versions
+## Exposure of Versions {#exposure-of-dataspace-protocol-versions}
 
 ### Generic Definition
 

--- a/specifications/common/common.protocol.md
+++ b/specifications/common/common.protocol.md
@@ -6,7 +6,7 @@ All requests to HTTPS endpoints should use the `Authorization` header to include
 of such tokens are not part of these specifications. The `Authorization` HTTP header is optional if the [=Connector=]
 does not require authorization.
 
-## Schemas, Contexts, and Message Processing
+## Schemas & Contexts
 
 All protocol messages are normatively defined by a [[json-schema]]. This specification also uses JSON-LD 1.1 and provides
 a JSON-LD context to serialize data structures and message types as it facilitates extensibility. The JSON-LD context is
@@ -15,7 +15,7 @@ type. This allows implementations to choose whether to process messages as plain
 interoperability between those approaches. Extensions that use JSON-LD are encouraged to provide similar contexts that
 facilitate this approach to interoperability.
 
-## Exposure of Dataspace Protocol Versions
+## Exposure of Versions
 
 ### Generic Definition
 

--- a/specifications/negotiation/contract.negotiation.binding.https.md
+++ b/specifications/negotiation/contract.negotiation.binding.https.md
@@ -41,20 +41,18 @@ authorization.
 
 ## Provider Path Bindings
 
-| Endpoint                                                              | Method | Description                                                 |
-|:----------------------------------------------------------------------|:-------|:------------------------------------------------------------|
-| https://provider.com/negotiations/:providerPid                        | `GET`  | [[[#negotiations-get-provider]]]                                    |
-| https://provider.com/negotiations/request                             | `POST` | [[[#negotiations-request-post]]]                            |
-| https://provider.com/negotiations/:providerPid/request                | `POST` | [[[#negotiations-providerpid-request-post]]]                |
-| https://provider.com/negotiations/:providerPid/events                 | `POST` | [[[#negotiations-providerpid-events-post]]]                 |
-| https://provider.com/negotiations/:providerPid/agreement/verification | `POST` | [[[#negotiations-providerpid-agreement-verification-post]]] |
-| https://provider.com/negotiations/:providerPid/termination            | `POST` | [[[#negotiations-providerpid-termination-post]]]            |
+| Endpoint                                                    | Method | Path                                                |
+|:------------------------------------------------------------|:-------|:----------------------------------------------------|
+| [[[#negotiations-get-provider]]]                                     | `GET`  | `/negotiations/:providerPid`                        |
+| [[[#negotiations-request-post]]]                            | `POST` | `/negotiations/request`                             |
+| [[[#negotiations-providerpid-request-post]]]                | `POST` | `/negotiations/:providerPid/request`                |
+| [[[#negotiations-providerpid-events-post]]]                 | `POST` | `/negotiations/:providerPid/events`                 |
+| [[[#negotiations-providerpid-agreement-verification-post]]] | `POST` | `/negotiations/:providerPid/agreement/verification` |
+| [[[#negotiations-providerpid-termination-post]]]            | `POST` | `/negotiations/:providerPid/termination`            |
 
-### The `negotiations` Endpoint _(Provider-side)_
+### Contract Negotiation Endpoint {#negotiations-get-provider}
 
-#### GET {#negotiations-get-provider}
-
-##### Request
+**Request**
 
 A CN can be accessed by a [=Consumer=] sending a GET request to `negotiations/:providerPid`:
 
@@ -65,7 +63,7 @@ Authorization: ...</pre>
 </aside>
 
 
-##### Response
+**Response**
 
 If the CN is found and the client is authorized, the [=Provider=] must return an HTTP 200 (OK) response and a body
 containing the [Contract Negotiation](#ack-contract-negotiation):
@@ -80,11 +78,9 @@ containing the [Contract Negotiation](#ack-contract-negotiation):
 Predefined states are: `REQUESTED`, `OFFERED`, `ACCEPTED`, `AGREED`, `VERIFIED`, `FINALIZED`, and `TERMINATED` (
 see [[[#contract-negotiation-states]]]).
 
-### The `negotiations/request` Endpoint _(Provider-side)_
+### Contract Request Endpoint (init) {#negotiations-request-post}
 
-#### POST {#negotiations-request-post}
-
-##### Request
+**Request**
 
 A CN is started and placed in the `REQUESTED` state when a [=Consumer=] POSTs an
 initiating [Contract Request Message](#contract-request-message)
@@ -104,7 +100,7 @@ Authorization: ...</pre>
   that [=Providers=] should properly handle the cases where a trailing `/` is included
   with or absent from the `callbackAddress` when resolving full URL.
 
-##### Response
+**Response**
 
 The [=Provider=] must return an HTTP 201 (Created) response with a body containing
 the [Contract Negotiation](#ack-contract-negotiation):
@@ -114,11 +110,9 @@ the [Contract Negotiation](#ack-contract-negotiation):
     </pre>
 </aside>
 
-### The `negotiations/:providerPid/request` Endpoint _(Provider-side)_
+### Contract Request Endpoint {#negotiations-providerpid-request-post}
 
-#### POST {#negotiations-providerpid-request-post}
-
-##### Request
+**Request**
 
 A [=Consumer=] may make an [=Offer=] by POSTing
 a [Contract Request Message](#contract-request-message)
@@ -131,16 +125,14 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the message is successfully processed, the [=Provider=] must return an HTTP 200 (OK) response. The response body is
 not specified and clients are not required to process it.
 
-### The `negotiations/:providerPid/events` Endpoint _(Provider-side)_
+### Contract Negotiation Event Endpoint {#negotiations-providerpid-events-post}
 
-#### POST {#negotiations-providerpid-events-post}
-
-##### Request
+**Request**
 
 A [=Consumer=] can POST
 a [Contract Negotiation Event Message](#contract-negotiation-event-message)
@@ -153,7 +145,7 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the CN's state is successfully transitioned, the [=Provider=] must return an HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it.
@@ -162,11 +154,9 @@ If the current [=Offer=] was created by the [=Consumer=], the [=Provider=] must 
 with a [Contract Negotiation Error](#error-contract-negotiation-error) in the
 response body.
 
-### The `negotiations/:providerPid/agreement/verification` Endpoint  _(Provider-side)_
+### Contract Agreement Verification Endpoint {#negotiations-providerpid-agreement-verification-post}
 
-#### POST {#negotiations-providerpid-agreement-verification-post}
-
-##### Request
+**Request**
 
 The [=Consumer=] can POST
 a [Contract Agreement Verification Message](#contract-agreement-verification-message)
@@ -179,16 +169,14 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the CN's state is successfully transitioned, the [=Provider=] must return an HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it.
 
-### The `negotiations/:providerPid/termination` Endpoint _(Provider-side)_
+### Contract Negotiation Termination Endpoint {#negotiations-providerpid-termination-post}
 
-#### POST {#negotiations-providerpid-termination-post}
-
-##### Request
+**Request**
 
 The [=Consumer=] can POST
 a [Contract Negotiation Termination Message](#contract-negotiation-termination-message)
@@ -201,36 +189,34 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the CN's state is successfully transitioned, the [=Provider=] must return HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it.
 
-## Consumer Callback Path Bindings
+## Consumer Path Bindings
 
-| Endpoint                                                             | Method | Description                                      |
-|:---------------------------------------------------------------------|:-------|:-------------------------------------------------|
-| https://consumer.com/negotiations/offers                             | `POST` | [[[#negotiations-offers-post]]]                  |
-| https://consumer.com/:callback/negotiations/:consumerPid             | `GET`  | [[[#negotiations-get-consumer]]]                 |
-| https://consumer.com/:callback/negotiations/:consumerPid/offers      | `POST` | [[[#negotiations-consumerpid-offers-post]]]      |
-| https://consumer.com/:callback/negotiations/:consumerPid/agreement   | `POST` | [[[#negotiations-consumerpid-agreement-post]]]   |
-| https://consumer.com/:callback/negotiations/:consumerPid/events      | `POST` | [[[#negotiations-consumerpid-events-post]]]      |
-| https://consumer.com/:callback/negotiations/:consumerPid/termination | `POST` | [[[#negotiations-consumerpid-termination-post]]] |
-
-**_Note:_** The `:callback` can be chosen freely by the implementations.
+| Endpoint                                         | Method | Path                                               |
+|:-------------------------------------------------|:-------|:---------------------------------------------------|
+| [[[#negotiations-get-consumer]]]                 | `GET`  | `/:callback/negotiations/:consumerPid`             |
+| [[[#negotiations-offers-post]]]                  | `POST` | `/negotiations/offers`                             |
+| [[[#negotiations-consumerpid-offers-post]]]      | `POST` | `/:callback/negotiations/:consumerPid/offers`      |
+| [[[#negotiations-consumerpid-agreement-post]]]   | `POST` | `/:callback/negotiations/:consumerPid/agreement`   |
+| [[[#negotiations-consumerpid-events-post]]]      | `POST` | `/:callback/negotiations/:consumerPid/events`      |
+| [[[#negotiations-consumerpid-termination-post]]] | `POST` | `/:callback/negotiations/:consumerPid/termination` |
 
 ### Prerequisites
 
 All callback paths are relative to the `callbackAddress` base URL specified in
 the [Contract Request Message](#contract-request-message) that initiated a CN. For example, if the `callbackAddress` is
-specified as `https://consumer.com/callback` and a callback path binding is `negotiations/:consumerPid/offers`, the
-resolved URL will be `https://consumer.com/callback/negotiations/:consumerPid/offers`.
+specified as `https://consumer.com/:callback` and a callback path binding is `negotiations/:consumerPid/offers`, the
+resolved URL will be `https://consumer.com/:callback/negotiations/:consumerPid/offers`.
 
-### The `negotiations` Endpoint _(Consumer-side)_
+**_Note:_** The `:callback` can be chosen freely by the implementations.
 
-#### GET {#negotiations-get-consumer}
+### Contract Negotiation Endpoint {#negotiations-get-consumer}
 
-##### Request
+**Request**
 
 A CN can be accessed by a [=Provider=] sending a GET request to the `negotiations/:consumerPid` callback:
 
@@ -241,7 +227,7 @@ Authorization: ...</pre>
 </aside>
 
 
-##### Response
+**Response**
 
 If the CN is found and the client is authorized, the [=Consumer=] must return an HTTP 200 (OK) response and a body
 containing the [Contract Negotiation](#ack-contract-negotiation):
@@ -256,11 +242,9 @@ containing the [Contract Negotiation](#ack-contract-negotiation):
 Predefined states are: `REQUESTED`, `OFFERED`, `ACCEPTED`, `AGREED`, `VERIFIED`, `FINALIZED`, and `TERMINATED` (
 see [[[#contract-negotiation-states]]]).
 
-### The `negotiations/offers` Endpoint _(Consumer-side)_
+### Contract Offer Endpoint (init) {#negotiations-offers-post}
 
-#### POST {#negotiations-offers-post}
-
-##### Request
+**Request**
 
 A CN is started and placed in the `OFFERED` state when a [=Provider=] POSTs
 a [Contract Offer Message](#contract-offer-message) to `negotiations/offers`:
@@ -279,7 +263,7 @@ Authorization: ...</pre>
   should properly handle the cases where a trailing / is included with or absent from the `callbackAddress` when
   resolving full URL.
 
-##### Response
+**Response**
 
 The [=Consumer=] must return an HTTP 201 (Created) response with a body containing
 the [Contract Negotiation](#ack-contract-negotiation):
@@ -289,11 +273,9 @@ the [Contract Negotiation](#ack-contract-negotiation):
     </pre>
 </aside>
 
-### The `negotiations/:consumerPid/offers` Endpoint _(Consumer-side)_
+### Contract Offer Endpoint {#negotiations-consumerpid-offers-post}
 
-#### POST {#negotiations-consumerpid-offers-post}
-
-##### Request
+**Request**
 
 A [=Provider=] may make an [=Offer=] by POSTing a [Contract Offer Message](#contract-offer-message) to
 the `negotiations/:consumerPid/offers` callback:
@@ -305,16 +287,14 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the message is successfully processed, the [=Consumer=] must return an HTTP 200 (OK) response. The response body is
 not specified and clients are not required to process it.
 
-### The `negotiations/:consumerPid/agreement` Endpoint _(Consumer-side)_
+### Contract Agreement Endpoint {#negotiations-consumerpid-agreement-post}
 
-#### POST {#negotiations-consumerpid-agreement-post}
-
-##### Request
+**Request**
 
 The [=Provider=] can POST a [Contract Agreement Message](#contract-agreement-message) to
 the `negotiations/:consumerPid/agreement` callback to create an [=Agreement=].
@@ -326,16 +306,14 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the CN's state is successfully transitioned, the [=Consumer=] must return an HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it.
 
-### The `negotiations/:consumerPid/events` Endpoint _(Consumer-side)_ 
+### Contract Negotiation Event Endpoint {#negotiations-consumerpid-events-post}
 
-#### POST {#negotiations-consumerpid-events-post}
-
-##### Request
+**Request**
 
 A [=Provider=] can POST a [Contract Negotiation Event Message](#contract-negotiation-event-message) to
 the `negotiations/:consumerPid/events` callback with an `eventType` of `FINALIZED` to finalize an [=Agreement=].
@@ -347,16 +325,14 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the CN's state is successfully transitioned, the [=Consumer=] must return HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it.
 
-### The `negotiations/:consumerPid/termination` Endpoint _(Consumer-side)_
+### Contract Negotiation Termination Endpoint {#negotiations-consumerpid-termination-post}
 
-#### POST {#negotiations-consumerpid-termination-post}
-
-##### Request
+**Request**
 
 The [=Provider=] can POST a [Contract Negotiation Termination Message](#contract-negotiation-termination-message) to
 terminate a CN.
@@ -368,7 +344,7 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the CN's state is successfully transitioned, the [=Consumer=] must return HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it.

--- a/specifications/transfer/transfer.process.binding.https.md
+++ b/specifications/transfer/transfer.process.binding.https.md
@@ -33,20 +33,18 @@ If the client is not authorized, the [=Consumer=] or [=Provider=] must return an
 
 ## Provider Path Bindings
 
-| Endpoint                                                | Method | Description                                   |
-|:--------------------------------------------------------|:-------|:----------------------------------------------|
-| https://provider.com/transfers/:providerPid             | `GET`  | [[[#transfers-get]]]                          |
-| https://provider.com/transfers/request                  | `POST` | [[[#transfers-request-post]]]                 |
-| https://provider.com/transfers/:providerPid/start       | `POST` | [[[#transfers-providerpid-start-post]]]       |
-| https://provider.com/transfers/:providerPid/completion  | `POST` | [[[#transfers-providerpid-completion-post]]]  |
-| https://provider.com/transfers/:providerPid/termination | `POST` | [[[#transfers-providerpid-termination-post]]] |
-| https://provider.com/transfers/:providerPid/suspension  | `POST` | [[[#transfers-providerpid-suspension-post]]]  |
+| Endpoint                                      | Method | Path                                  |
+|:----------------------------------------------|:-------|:--------------------------------------|
+| [[[#transfers-get]]]                          | `GET`  | `/transfers/:providerPid`             |
+| [[[#transfers-request-post]]]                 | `POST` | `/transfers/request`                  |
+| [[[#transfers-providerpid-start-post]]]       | `POST` | `/transfers/:providerPid/start`       |
+| [[[#transfers-providerpid-completion-post]]]  | `POST` | `/transfers/:providerPid/completion`  |
+| [[[#transfers-providerpid-termination-post]]] | `POST` | `/transfers/:providerPid/termination` |
+| [[[#transfers-providerpid-suspension-post]]]  | `POST` | `/transfers/:providerPid/suspension`  |
 
-### The `transfers` Endpoint _(Provider-side)_
+### Transfer Process Endpoint {#transfers-get}
 
-#### GET {#transfers-get}
-
-##### Request
+**Request**
 
 A CN can be accessed by a [=Consumer=] or [=Provider=] sending a GET request to `transfers/:providerPid`:
 
@@ -55,7 +53,7 @@ A CN can be accessed by a [=Consumer=] or [=Provider=] sending a GET request to 
 Authorization: ...</pre>
 </aside>
 
-##### Response
+**Response**
 
 If the TP is found and the client is authorized, the [=Provider=] must return an HTTP 200 (OK) response and a body
 containing the [Transfer Process](#ack-transfer-process):
@@ -69,11 +67,9 @@ Authorization: ...</pre>
 
 Predefined states are: `REQUESTED`, `STARTED`, `SUSPENDED`, `REQUESTED`, `COMPLETED`, and `TERMINATED`.
 
-### The `transfers/request` Endpoint _(Provider-side)_
+### Transfer Request Endpoint {#transfers-request-post}
 
-#### POST {#transfers-request-post}
-
-##### Request
+**Request**
 
 A TP is started and placed in the `REQUESTED` state when a [=Consumer=] POSTs
 a [Transfer Request Message](#transfer-request-message) to `transfers/request`:
@@ -92,7 +88,7 @@ Authorization: ...</pre>
   that [=Providers=] should properly handle the cases where a trailing `/` is included
   with or absent from the `callbackAddress` when resolving full URL.
 
-##### Response
+**Response**
 
 The [=Provider=] must return an HTTP 201 (Created) response with a body containing
 the [Transfer Process](#ack-transfer-process):
@@ -102,11 +98,9 @@ the [Transfer Process](#ack-transfer-process):
     </pre>
 </aside>
 
-### The `transfers/:providerPid/start` Endpoint _(Provider-side)_
+### Transfer Start Endpoint {#transfers-providerpid-start-post}
 
-#### POST {#transfers-providerpid-start-post}
-
-##### Request
+**Request**
 
 The [=Consumer=] can POST a [Transfer Start Message](#transfer-start-message) to
 attempt to start a TP after it has been suspended:
@@ -118,16 +112,14 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the TP's state is successfully transitioned, the [=Provider=] must return HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it.
 
-### The `transfers/:providerPid/completion` Endpoint _(Provider-side)_
+### Transfer Completion Endpoint {#transfers-providerpid-completion-post}
 
-#### POST {#transfers-providerpid-completion-post}
-
-##### Request
+**Request**
 
 The [=Consumer=] can POST a [Transfer Completion Message](#transfer-completion-message)
 to complete a TP:
@@ -139,16 +131,14 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the TP's state is successfully transitioned, the [=Provider=] must return HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it.
 
-### The `transfers/:providerPid/termination` Endpoint _(Provider-side)_
+### Transfer Termination Endpoint {#transfers-providerpid-termination-post}
 
-#### POST {#transfers-providerpid-termination-post}
-
-##### Request
+**Request**
 
 The [=Consumer=] can POST
 a [Transfer Termination Message](#transfer-termination-message) to terminate a TP:
@@ -160,16 +150,14 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the TP's state is successfully transitioned, the [=Provider=] must return HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it.
 
-### The `transfers/:providerPid/suspension` Endpoint _(Provider-side)_
+### Transfer Suspension Endpoint {#transfers-providerpid-suspension-post}
 
-#### POST {#transfers-providerpid-suspension-post}
-
-##### Request
+**Request**
 
 The [=Consumer=] can POST a [Transfer Suspension Message](#transfer-suspension-message)
 to suspend a TP:
@@ -181,33 +169,33 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the TP's state is successfully transitioned, the [=Provider=] must return HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it.
 
 ## Consumer Callback Path Bindings
 
-| Endpoint                                                          | Method | Description                                   |
-|:------------------------------------------------------------------|:-------|:----------------------------------------------|
-| https://consumer.com/:callback/transfers/:consumerPid/start       | `POST` | [[[#transfers-consumerpid-start-post]]]       |
-| https://consumer.com/:callback/transfers/:consumerPid/completion  | `POST` | [[[#transfers-consumerpid-completion-post]]]  |
-| https://consumer.com/:callback/transfers/:consumerPid/termination | `POST` | [[[#transfers-consumerpid-termination-post]]] |
-| https://consumer.com/:callback/transfers/:consumerPid/suspension  | `POST` | [[[#transfers-consumerpid-suspension-post]]] |
+| Endpoint                                      | Method | Path                                            |
+|:----------------------------------------------|:-------|:------------------------------------------------|
+| [[[#transfers-consumerpid-start-post]]]       | `POST` | `/:callback/transfers/:consumerPid/start`       |
+| [[[#transfers-consumerpid-completion-post]]]  | `POST` | `/:callback/transfers/:consumerPid/completion`  |
+| [[[#transfers-consumerpid-termination-post]]] | `POST` | `/:callback/transfers/:consumerPid/termination` |
+| [[[#transfers-consumerpid-suspension-post]]]  | `POST` | `/:callback/transfers/:consumerPid/suspension`  |
 
 ### Prerequisites
 
 All callback paths are relative to the `callbackAddress` base URL specified in
 the [Transfer Request Message](#transfer-request-message) that initiated a TP. For
-example, if the `callbackAddress` is specified as `https://consumer.com/callback` and a callback path binding
+example, if the `callbackAddress` is specified as `https://consumer.com/:callback` and a callback path binding
 is `transfers/:consumerPid/start`, the resolved URL will
-be `https://consumer.com/callback/transfers/:consumerPid/start`.
+be `https://consumer.com/:callback/transfers/:consumerPid/start`.
 
-### The `transfers/:consumerPid/start` Endpoint _(Consumer-side)_
+**_Note:_** The `:callback` can be chosen freely by the implementations.
 
-#### POST {#transfers-consumerpid-start-post}
+### Transfer Start Endpoint {#transfers-consumerpid-start-post}
 
-##### Request
+**Request**
 
 The [=Provider=] can POST a [Transfer Start Message](#transfer-start-message) to
 indicate the start of a TP:
@@ -219,16 +207,14 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the TP's state is successfully transitioned, the [=Consumer=] must return HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it.
 
-### The `transfers/:consumerPid/completion` Endpoint _(Consumer-side)_
+### Transfer Completion Endpoint {#transfers-consumerpid-completion-post}
 
-#### POST {#transfers-consumerpid-completion-post}
-
-##### Request
+**Request**
 
 The [=Provider=] can POST a [Transfer Completion Message](#transfer-completion-message)
 to complete a TP:
@@ -240,16 +226,14 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the TP's state is successfully transitioned, the [=Consumer=] must return HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it.
 
-### The `transfers/:consumerPid/termination` Endpoint _(Consumer-side)_
+### Transfer Termination Endpoint {#transfers-consumerpid-termination-post}
 
-#### POST {#transfers-consumerpid-termination-post}
-
-##### Request
+**Request**
 
 The [=Provider=] can POST
 a [Transfer Termination Message](#transfer-termination-message) to terminate a TP:
@@ -261,16 +245,14 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the TP's state is successfully transitioned, the [=Consumer=] must return HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it.
 
-### The `transfers/:consumerPid/suspension` Endpoint _(Consumer-side)_
+### Transfer Suspension Endpoint {#transfers-consumerpid-suspension-post}
 
-#### POST {#transfers-consumerpid-suspension-post}
-
-##### Request
+**Request**
 
 The [=Provider=] can POST a [Transfer Suspension Message](#transfer-suspension-message)
 to suspend a TP:
@@ -282,7 +264,7 @@ Authorization: ...</pre>
     </pre>
 </aside>
 
-##### Response
+**Response**
 
 If the TP's state is successfully transitioned, the [=Consumer=] must return HTTP code 200 (OK). The response body is
 not specified and clients are not required to process it. 


### PR DESCRIPTION
## What this PR changes/adds

Cleans up section headings for a better readability of ToC and binding documents.

## Why it does that

Unnessessary duplicated information. Alignment with message section.

Now:
![image](https://github.com/user-attachments/assets/b4ec201c-862f-4bb2-a2a3-f6a3448bd99d)
![image](https://github.com/user-attachments/assets/0eb4a38a-f80d-452c-b2d1-b74fe8186ae1)

Then:
![image](https://github.com/user-attachments/assets/472c510b-2c1b-47aa-a6b8-a850618b909b)
![image](https://github.com/user-attachments/assets/67873ca2-9b40-4ad4-a093-102f267bfb08)

## Further notes

--

## Linked Issue(s)

Closes # <-- _insert issue number if one exists_

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._