### PR TITLE
chore: add lower-level type definitions table to annex

### DIFF
--- a/artifacts/src/main/resources/transfer/data-address-schema.json
+++ b/artifacts/src/main/resources/transfer/data-address-schema.json
@@ -25,24 +25,7 @@
         "endpointProperties": {
           "type": "array",
           "items": {
-            "type": "object",
-            "properties": {
-              "@type": {
-                "type": "string",
-                "const": "EndpointProperty"
-              },
-              "name": {
-                "type": "string"
-              },
-              "value": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "@type",
-              "name",
-              "value"
-            ]
+            "$ref": "#/definitions/EndpointProperty"
           },
           "minItems": 1
         }
@@ -51,6 +34,26 @@
         "@type",
         "endpointType",
         "endpoint"
+      ]
+    },
+    "EndpointProperty": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string",
+          "const": "EndpointProperty"
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "@type",
+        "name",
+        "value"
       ]
     }
   }

--- a/index.html
+++ b/index.html
@@ -124,6 +124,10 @@
 
 <section id='conformance'></section>
 
+<section id="lower-level-types" class="appendix" data-include="specifications/common/type-definitions.md" data-include-format="markdown">
+    <h1>Lower-level type definitions</h1>
+</section>
+
 <section id="tof" class="appendix">
     <h1>Notes</h1>
 </section>

--- a/specifications/common/type-definitions.md
+++ b/specifications/common/type-definitions.md
@@ -1,0 +1,41 @@
+# Lower Level Type Definitions
+
+<p data-include="message/table/action.html" data-include-format="html">
+</p>
+
+
+<p data-include="message/table/constraint.html" data-include-format="html">
+</p>
+
+
+<p data-include="message/table/dataaddress.html" data-include-format="html">
+</p>
+
+<p data-include="message/table/distribution.html" data-include-format="html">
+</p>
+
+
+<p data-include="message/table/duty.html" data-include-format="html">
+</p>
+
+
+<p data-include="message/table/dataservice.html" data-include-format="html">
+</p>
+
+
+<p data-include="message/table/endpointproperty.html" data-include-format="html">
+</p>
+
+
+<p data-include="message/table/messageoffer.html" data-include-format="html">
+</p>
+
+
+<p data-include="message/table/offer.html" data-include-format="html">
+</p>
+
+
+<p data-include="message/table/permission.html" data-include-format="html">
+</p>
+
+


### PR DESCRIPTION
## What this PR changes/adds

add the pipeline generated tables to a new section in the annex. The generation logic was updated so that links are built automatically. This also required the refactoring of the dataaddress schema.

## Why it does that

readability

## Linked Issue(s)

Closes #82

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._