### PR TITLE
docs: fix author section

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
           editors: [{
               name: "Sebastian Steinbuss",
               url: "https://github.com/ssteinbuss",
-              company: "International Dataspaces Association",
+              company: "International Data Spaces Association",
               companyURL: "https://internationaldataspaces.org/",
           }],
             authors: [
@@ -39,12 +39,12 @@
                 {
                   name: "Anil Turkmayali",
                   url: "https://github.com/anilturkmayali",
-                  company: "International Dataspaces Association"
+                  company: "International Data Spaces Association"
                 },
                 {
                   name: "Sebastian Steinbuss",
                   url: "https://github.com/ssteinbuss",
-                  company: "International Dataspaces Association"
+                  company: "International Data Spaces Association"
                 },
                 {
                   name: "Arno Weiß",


### PR DESCRIPTION
## What this PR changes/adds

Change "International Dataspaces Association" to "International Data Spaces Association"

## Why it does that

The name of the organisation is fixed.

## Linked Issue(s)

Amends #118

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._