### PR TITLE
chore: publish version `2025-1-RC1`

### DIFF
--- a/.github/scripts/checkout-tags.sh
+++ b/.github/scripts/checkout-tags.sh
@@ -13,7 +13,7 @@ do
   echo starting with tag $tag
   mkdir $tag
   cd $tag
-  git clone https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocl.git --depth 1 --branch ${tag} --quiet
+  git clone https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol.git --depth 1 --branch ${tag} --quiet
   mv ./DataspaceProtocol/* .
   cd ..
 done

--- a/.github/scripts/index.html
+++ b/.github/scripts/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="refresh"
-          content="0;url=https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/HEAD"/>
-    <link rel="canonical" href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/HEAD"/>
+          content="0;url=https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC1"/>
+    <link rel="canonical" href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC1"/>
 </head>
 <body>
 <h4>
-    This redirects to the latest Release Candidate <a href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/HEAD">here</a>
+    This redirects to the latest Release Candidate <a href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC1">here</a>
 </h4>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,7 @@
     <script class="remove" src="https://cdn.jsdelivr.net/gh/w3c/respec-mermaid@1.1.0/dist/main.js"></script>
     <script class='remove'>
         var respecConfig = {
-          specStatus: "base",
-          publishDate: "2025-02-27",
+          specStatus: "unofficial",
           latestVersion: "https://docs.internationaldataspaces.org/ids-knowledgebase/dataspace-protocol",
           editors: [{
               name: "Sebastian Steinbuss",
@@ -62,13 +61,13 @@
           maxTocLevel: 3,
         };
     </script>
-    <title>Dataspace Protocol Release 2025-1-RC1</title>
+    <title>Dataspace Protocol Release 2025-1-RC2</title>
 </head>
 <body>
 <p class="copyright">
     This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License, Version 2.0</a>.
 </p>
-<h1 id="title">Dataspace Protocol 2025-1-RC1</h1>
+<h1 id="title">Dataspace Protocol 2025-1-RC2</h1>
 <section id='abstract'>
     <p>
         The Dataspace Protocol is a set of specifications designed to facilitate interoperable data sharing between

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@
     <script class="remove" src="https://cdn.jsdelivr.net/gh/w3c/respec-mermaid@1.1.0/dist/main.js"></script>
     <script class='remove'>
         var respecConfig = {
-          specStatus: "unofficial",
+          specStatus: "base",
+          publishDate: "2025-02-27",
           latestVersion: "https://docs.internationaldataspaces.org/ids-knowledgebase/dataspace-protocol",
-          postProcess: [window.respecMermaid.createFigures],
           editors: [{
               name: "Sebastian Steinbuss",
               url: "https://github.com/ssteinbuss",
@@ -49,7 +49,7 @@
                 {
                   name: "Arno Weiß",
                   url: "https://github.com/arnoweiss",
-                  company: "SAP SE"
+                  company: "SAP"
                 },
               ],
           github: {
@@ -62,13 +62,13 @@
           maxTocLevel: 3,
         };
     </script>
-    <title>Dataspace Protocol Release 2025-1</title>
+    <title>Dataspace Protocol Release 2025-1-RC1</title>
 </head>
 <body>
 <p class="copyright">
     This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License, Version 2.0</a>.
 </p>
-<h1 id="title">Dataspace Protocol</h1>
+<h1 id="title">Dataspace Protocol 2025-1-RC1</h1>
 <section id='abstract'>
     <p>
         The Dataspace Protocol is a set of specifications designed to facilitate interoperable data sharing between
@@ -124,7 +124,7 @@
 
 <section id='conformance'></section>
 
-<section id="lower-level-types" class="appendix" data-include="specifications/common/type-definitions.md" data-include-format="markdown">
+<section id="lower-level-types" class="appendix" data-include="specifications/common/type.definitions.md" data-include-format="markdown">
     <h1>Lower-level type definitions</h1>
 </section>
 

--- a/specifications/catalog/catalog.protocol.md
+++ b/specifications/catalog/catalog.protocol.md
@@ -62,12 +62,12 @@ provided in protocol-dependent forms, e.g., for an HTTPS binding in the request 
 
 ### ACK - Catalog
 
-|                |                                                                               |
-|----------------|-------------------------------------------------------------------------------|
-| **Sent by**    | [=Provider=]                                                                  |
-| **Schema**     | [JSON Schema](message/schema/catalog-schema.json)                             |
-| **Example**    | [Catalog Example](message/example/catalog.json)                               |
-| **Properties**      | <p data-include="message/table/catalog.html" data-include-format="html"></p> |
+|                |                                                                                  |
+|----------------|----------------------------------------------------------------------------------|
+| **Sent by**    | [=Provider=]                                                                     |
+| **Schema**     | [JSON Schema](message/schema/catalog-schema.json)                                |
+| **Example**    | [Catalog Example](message/example/catalog.json)                                  |
+| **Properties**      | <p data-include="message/table/rootcatalog.html" data-include-format="html"></p> |
 
 * A [=Catalog=] _MUST_ have zero to many [=Datasets=]. (_NOTE: Since a Catalog may be dynamically generated for a request based on the requesting [=Participant=]'s credentials, it is possible for it to contain 0 matching [=Datasets=]._)
 * A [=Catalog=] _MUST_ have one to many [=Data Services=] that reference a [=Connector=] where [=Datasets=] may be obtained.

--- a/specifications/common/type.definitions.md
+++ b/specifications/common/type.definitions.md
@@ -8,6 +8,9 @@
 </p>
 
 
+<p data-include="message/table/catalog.html" data-include-format="html">
+</p>
+
 <p data-include="message/table/dataaddress.html" data-include-format="html">
 </p>
 


### PR DESCRIPTION
## What this PR changes/adds

This PR publishes a separate github page for the current state of the spec as a first Release Candidate for version `2025-1`.

## Why it does that

Lots of new features.

## Further notes

**There is further action required from the committer who merges this PR.**
Github does not allow to merge tags via PRs. Every committer however can push tags to main. After merging this PR, a committer must:
1. create a tag called `2025-1-RC1` on commit [d8f6428a1b7a9a9be13719c226eaa8d9cbb5adc9](https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol/commit/d8f6428a1b7a9a9be13719c226eaa8d9cbb5adc9) and push if done in IDE.
2. rerun all github actions.

This will lead to a setup like in my fork:
https://arnoweiss.github.io/DataspaceProtocol/
https://arnoweiss.github.io/DataspaceProtocol/2025-1-RC1/
https://arnoweiss.github.io/DataspaceProtocol/HEAD/