### PR TITLE
feat: restrict the logical constraints domain

### DIFF
--- a/artifacts/src/main/resources/negotiation/contract-schema.json
+++ b/artifacts/src/main/resources/negotiation/contract-schema.json
@@ -213,28 +213,27 @@
       "properties": {
         "and": {
           "type": "array",
-          "items": "object"
+          "items": {
+            "$ref": "#/definitions/Constraint"
+          }
         },
         "andSequence": {
           "type": "array",
-          "items": "object"
+          "items": {
+            "$ref": "#/definitions/Constraint"
+          }
         },
         "or": {
           "type": "array",
           "items": {
-            "oneOf": [
-              {
-                "$ref": "#/definitions/LogicalConstraint"
-              },
-              {
-                "$ref": "#/definitions/AtomicConstraint"
-              }
-            ]
+            "$ref": "#/definitions/Constraint"
           }
         },
         "xone": {
           "type": "array",
-          "items": "object"
+          "items": {
+            "$ref": "#/definitions/Constraint"
+          }
         }
       },
       "oneOf": [

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidPolicySchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidPolicySchemaTest.java
@@ -32,6 +32,7 @@ public class InvalidPolicySchemaTest extends AbstractSchemaTest {
         assertThat(schema.validate(INVALID_NO_OPERATOR, JSON).iterator().next().getType()).isEqualTo(ONE_OF);
         assertThat(schema.validate(INVALID_NO_RIGHT_OPERAND, JSON).iterator().next().getType()).isEqualTo(ONE_OF);
         assertThat(schema.validate(INVALID_MULTIPLICITY_CONSTRAINT, JSON).iterator().next().getType()).isEqualTo(ONE_OF);
+        assertThat(schema.validate(INVALID_LOGICAL_CONTENT_NESTING, JSON).iterator().next().getType()).isEqualTo(ONE_OF);
     }
 
     @BeforeEach
@@ -154,6 +155,34 @@ public class InvalidPolicySchemaTest extends AbstractSchemaTest {
                            "leftOperand": "partner",
                            "operator": "eq",
                            "rightOperand": "silver"
+                         }
+                       ]
+                     }
+                   }
+                 ]
+               }
+            """;
+
+    private static final String INVALID_LOGICAL_CONTENT_NESTING = """
+            {
+                 "@id": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
+                 "@type": "Offer",
+                 "target": "asset:1",
+                 "permission": [
+                   {
+                     "action": "use",
+                     "constraint": {
+                       "and": [
+                         {
+                           "leftOperand": "partner",
+                           "operator": "eq",
+                           "rightOperand": "gold"
+                         },
+                         {
+                           "something": "that",
+                           "is": "definitely",
+                           "not": "a",
+                           "valid": "constraint"
                          }
                        ]
                      }


### PR DESCRIPTION
## What this PR changes/adds

Currently, a logical constraint may contain anything. This PR restricts that to an array of the Constaint class. 

## Why it does that

type-safety

## Further notes

added a test.

## Linked Issue(s)

Closes #93

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._