### PR TITLE
feat: upgrade version endpoint

### DIFF
--- a/artifacts/src/main/resources/common/example/protocol-version.json
+++ b/artifacts/src/main/resources/common/example/protocol-version.json
@@ -1,8 +1,34 @@
 {
   "protocolVersions": [
     {
-      "version": "1.0",
-      "path": "/some/path/v1"
+      "version": "2025-1",
+      "path": "/some/path/2025-1",
+      "binding": "HTTPS"
+    },
+    {
+      "version": "2024-1",
+      "path": "/some/path/2024-1",
+      "binding": "HTTPS",
+      "auth": {
+        "protocol": "OAuth",
+        "version": "2",
+        "profile": [
+          "authorization_code",
+          "refresh_token"
+        ]
+      }
+    },
+    {
+      "version": "2025-1",
+      "path": "/different/path/2025-1",
+      "binding": "HTTPS",
+      "auth": {
+        "protocol": "DCP",
+        "version": "1.0",
+        "profile": [
+          "vc11-sl2021/jwt"
+        ]
+      }
     }
   ]
 }

--- a/artifacts/src/main/resources/common/protocol-version-schema.json
+++ b/artifacts/src/main/resources/common/protocol-version-schema.json
@@ -1,35 +1,72 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "title": "VersionSchema",
-    "type": "object",
-    "allOf": [
-        {
-            "$ref": "#/definitions/Version"
-        }
-    ],
-    "$id": "https://w3id.org/dspace/2025/1/common/protocol-version-schema.json",
-    "definitions": {
-        "Version": {
-            "type": "object",
-            "properties": {
-                "protocolVersions": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "version": {
-                                "type": "string"
-                            },
-                            "path": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["version", "path"]
-                    },
-                    "minItems": 1
-                }
-            },
-            "required": ["protocolVersions"]
-        }
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "VersionSchema",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "#/definitions/Version"
     }
+  ],
+  "$id": "https://w3id.org/dspace/2025/1/common/protocol-version-schema.json",
+  "definitions": {
+    "VersionResponse": {
+      "type": "object",
+      "properties": {
+        "protocolVersions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Version"
+          },
+          "minItems": 1
+        }
+      },
+      "required": [
+        "protocolVersions"
+      ]
+    },
+    "Version": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string"
+        },
+        "binding": {
+          "type": "string",
+          "enum": [
+            "HTTPS"
+          ]
+        },
+        "auth": {
+          "$ref": "#/definitions/Auth"
+        }
+      },
+      "required": [
+        "version",
+        "path",
+        "binding"
+      ]
+    },
+    "Auth": {
+      "type": "object",
+      "properties": {
+        "protocol": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "profile": {
+          "type": "array",
+          "items": "string"
+        }
+      },
+      "required": [
+        "protocol",
+        "version"
+      ]
+    }
+  }
 }

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/common/InvalidVersionSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/common/InvalidVersionSchemaTest.java
@@ -31,6 +31,11 @@ public class InvalidVersionSchemaTest extends AbstractSchemaTest {
         assertThat(schema.validate(INVALID_EMPTY_VERSIONS, JSON).iterator().next().getType()).isEqualTo(MIN_ITEMS);
         assertThat(schema.validate(INVALID_NO_VERSION, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
         assertThat(schema.validate(INVALID_NO_PATH, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
+        assertThat(schema.validate(INVALID_NO_BINDING, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
+        assertThat(schema.validate(INVALID_BINDING_NOT_IN_ENUM, JSON).iterator().next().getType()).isEqualTo(ENUM);
+        assertThat(schema.validate(INVALID_AUTH_A_STRING, JSON).iterator().next().getType()).isEqualTo(TYPE);
+        assertThat(schema.validate(INVALID_AUTH_MISSING_PROTOCOL, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
+        assertThat(schema.validate(INVALID_AUTH_NOT_AN_ARRAY, JSON).iterator().next().getType()).isEqualTo(TYPE);
     }
 
     @BeforeEach
@@ -63,6 +68,74 @@ public class InvalidVersionSchemaTest extends AbstractSchemaTest {
               "protocolVersions": [
                 {
                   "version": "1.0"
+                }
+              ]
+            }
+            """;
+
+    private static final String INVALID_NO_BINDING = """
+            {
+              "protocolVersions": [
+                {
+                  "version": "1.0",
+                  "path": "some/path/v1"
+                }
+              ]
+            }
+            """;
+
+    private static final String INVALID_BINDING_NOT_IN_ENUM = """
+            {
+              "protocolVersions": [
+                {
+                  "version": "1.0",
+                  "path": "mqtts://mycorp.com/some/path/v1",
+                  "binding": "MQTT",
+                  "auth": "auth-protocol"
+                }
+              ]
+            }
+            """;
+
+    private static final String INVALID_AUTH_A_STRING = """
+            {
+              "protocolVersions": [
+                {
+                  "version": "1.0",
+                  "path": "/some/path/v1",
+                  "binding": "HTTPS",
+                  "auth": "auth-protocol"
+                }
+              ]
+            }
+            """;
+
+    private static final String INVALID_AUTH_MISSING_PROTOCOL = """
+            {
+              "protocolVersions": [
+                {
+                  "version": "1.0",
+                  "path": "/some/path/v1",
+                  "binding": "HTTPS",
+                  "auth": {
+                    "version": "a.b.c",
+                    "profile": ["someprofile"]
+                  }
+                }
+              ]
+            }
+            """;
+    private static final String INVALID_AUTH_NOT_AN_ARRAY = """
+            {
+              "protocolVersions": [
+                {
+                  "version": "1.0",
+                  "path": "/some/path/v1",
+                  "binding": "HTTPS",
+                  "auth": {
+                    "version": "a.b.c",
+                    "profile": "someprofile"
+                  }
                 }
               ]
             }

--- a/specifications/common/common.protocol.md
+++ b/specifications/common/common.protocol.md
@@ -17,52 +17,32 @@ similar contexts that facilitate this approach to interoperability.
 
 ## Exposure of Versions {#exposure-of-dataspace-protocol-versions}
 
-### Generic Definition
+[=Connectors=] implementing the [=Dataspace Protocol=] may operate on different versions and bindings. Therefore, it is
+necessary that they can discover such information reliably and unambiguously. Each [=Connector=]
+must provide the version metadata endpoint using the `dspace-version` Well-Known Uniform Resource Identifier [[rfc8615]]
+at the top of the path hierarchy. Example: `<host>/.well-known/dspace-version`
 
-[=Connectors=] implementing the [=Dataspace Protocol=] may operate on different versions. Therefore, it is necessary
-that they can discover the supported versions of each other reliably and unambiguously. Each [=Connector=] must expose
-information of at least one Dataspace Protocol version it supports. The specifics of how this information is obtained
-its defined by specific protocol bindings.
-
-A [=Connector=] must respond to a respective request by providing a JSON object containing an array of supported
-versions with at least one item. The item connects the version tag (`version` attribute) with the absolute URL path
-segment of the domain-only path for all endpoints of this version. The following example specifies that
-this [=Connector=] offers version `2024-1` endpoints at `<host>/some/path/2024-1`, the `2025-1` endpoints at
-`<host>/some/path/2025-1` and another [=Connector=] on the same host under `<host>/different/path/2025-1`.
-
-```json
-{
-  "protocolVersions": [
-    {
-      "version": "2024-1",
-      "path": "/some/path/2024-1"
-    },
-    {
-      "version": "2025-1",
-      "path": "/some/path/2025-1"
-    },
-    {
-      "version": "2025-1",
-      "path": "/different/path/2025-1"
-    }
-  ]
-}
-```
+A [=Connector=] must respond to a respective HTTPS request by returning a [`VersionResponse`](#VersionResponse-table)
+with at least one item. The item connects the version tag (`version` attribute) with a path to the endpoint.
+The semantics of the `path` property are specified by each protocol binding.
 
 This data object must comply to the [JSON Schema](message/schema/protocol-version-schema.json). The requesting
 [=Connector=] may select from the endpoints in the response. If the [=Connector=] can't identify a matching Dataspace
-Protocol Version, it must terminate the communication.
+Protocol version, it must terminate the communication. The version endpoint MUST be unversioned and unauthenticated.
 
 ### HTTPS Binding
 
-#### The Well-Known Version Metadata Endpoint
+When using the DSP HTTPS binding, the `path` property is an absolute URL path segment to be appended to the domain for
+all endpoints of this version.
 
-Each implementation must provide the version metadata endpoint, which must use the `dspace-version` Well-Known Uniform
-Resource Identifier [[rfc8615]] at the top of the path hierarchy:
+The following example demonstrates that a [=Connector=] offers the HTTPS binding from version `2024-1` at
+`<host>/some/path/2024-1`, the `2025-1` endpoints at`<host>/some/path/2025-1` and another [=Connector=] on the same host
+under `<host>/different/path/2025-1` - some of which signal the relevant authentication protocol overlay, determined by
+`protocol`, `version` and the `profile` array.
 
-```
-/.well-known/dspace-version
-```
-
-The contents of the response is a JSON object defined in section [[[#exposure-of-dataspace-protocol-versions]]]. The
-version endpoint MUST be unversioned and unauthenticated.
+<aside class="example" title="well-known version endpoint (HTTPS)">
+    <pre class="http">GET https://provider.com/.well-known/dspace-version
+    </pre>
+    <pre class="json" data-include="message/example/protocol-version.json">
+    </pre>
+</aside>

--- a/specifications/common/type.definitions.md
+++ b/specifications/common/type.definitions.md
@@ -3,10 +3,11 @@
 <p data-include="message/table/action.html" data-include-format="html">
 </p>
 
+<p data-include="message/table/auth.html" data-include-format="html">
+</p>
 
 <p data-include="message/table/constraint.html" data-include-format="html">
 </p>
-
 
 <p data-include="message/table/catalog.html" data-include-format="html">
 </p>
@@ -17,28 +18,26 @@
 <p data-include="message/table/distribution.html" data-include-format="html">
 </p>
 
-
 <p data-include="message/table/duty.html" data-include-format="html">
 </p>
-
 
 <p data-include="message/table/dataservice.html" data-include-format="html">
 </p>
 
-
 <p data-include="message/table/endpointproperty.html" data-include-format="html">
 </p>
-
 
 <p data-include="message/table/messageoffer.html" data-include-format="html">
 </p>
 
-
 <p data-include="message/table/offer.html" data-include-format="html">
 </p>
-
 
 <p data-include="message/table/permission.html" data-include-format="html">
 </p>
 
+<p data-include="message/table/versionresponse.html" data-include-format="html">
+</p>
 
+<p data-include="message/table/version.html" data-include-format="html">
+</p>


### PR DESCRIPTION
## What this PR changes/adds

This PR changes the setup of the common versioning endpoint.
1. Restrict versioning-endpoint to HTTPS across bindings
Even in a distant future when there may be different bindings for DSP messages, it is reasonable to expect that the well-known HTTPS endpoint will be queried for which endpoints are relevant. A consumer has to start somewhere and it cannot be assumed that the DSP-binding a Provider uses is necessarily known.
2. Add the `auth` and `binding` properties
The `auth` property holds a string telling the Consumer how to authenticate to the Provider's DSP endpoints. This is necessary, especially if the catalog-endpoints are protected already. The `binding` property describes the DSP-protocol binding so the Consumer knows not just WHERE to ask but also HOW. This is relevant for forward-compatibility.

## Why it does that

Currently, the endpoint is neither useful (Consumer is likely unaware of authentication method) nor future-proof (introducing a new binding would render it useless).

## Further notes

I'd like at least two concurring reviews as this is a consequential change. Despite that, it's backward compatible because (1) there is no binding apart from HTTPS and (2) all newly introduced properties are optional.

Closes #112

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._