### PR TITLE
chore: add "data transfer protocol" to terms and definitions

### DIFF
--- a/specifications/common/introduction.md
+++ b/specifications/common/introduction.md
@@ -2,7 +2,7 @@
 
 The __Dataspace Protocol__ is used in the context of [=Dataspaces=] as described and defined in the subsequent sections with the purpose to support _interoperability_. In this context, the specification provides fundamental technical interoperability for [=Participants=] in [=Dataspaces=]. 
 
-This specification builds on protocols located in the [ISO OSI model (ISO/IEC 7498-1:1994)](https://www.iso.org/standard/20269.html) layers, like HTTPS. The purpose of this specification is to define interactions between systems independent of such protocols, but describing how to implement it in an unambiguous and extensible way. To do so, the [=Messages=] that are exchanged during the process are described in this specification and the states and their transitions are specified as state machines, based on the key terms and concepts of a [=Dataspace=]. On this foundation the bindings to data transfer protocols, like HTTPS, are described.
+This specification builds on protocols located in the [ISO OSI model (ISO/IEC 7498-1:1994)](https://www.iso.org/standard/20269.html) layers, like HTTPS. The purpose of this specification is to define interactions between systems independent of such protocols, but describing how to implement it in an unambiguous and extensible way. To do so, the [=Messages=] that are exchanged during the process are described in this specification and the states and their transitions are specified as state machines, based on the key terms and concepts of a [=Dataspace=]. On this foundation the bindings to [=Data Transfer Protocols=], like HTTPS, are described.
 
 _Note: This specification does not cover the data transfer as such. While this is controlled by the [=Transfer Process Protocol=], e.g., the initiation of the transfer channels or their decomissioning, the data transfer itself and especially the handling of technical exceptions is an obligation to the transport protocol._
 
@@ -14,4 +14,4 @@ This specification is organized into the following documents:
 * [[[#requirements]]] declares cross-cutting functions as, e.g., the declaration of supported versions of this protocol and common data processing rules.
 * [[[#catalog-protocol]]] and [[[#catalog-http]]] define how [=Catalogs=] are published and accessed as HTTPS endpoints respectively.
 * [[[#negotiation-protocol]]] and [[[#negotiation-http]]] documents that define how [=Contract Negotiations=] are conducted and requested via HTTPS endpoints.
-* [[[#transfer-protocol]]] and [[[#transfer-http]]] documents that define how [=Transfer Processes=] using a given data transfer protocol are governed via HTTPS endpoints.
+* [[[#transfer-protocol]]] and [[[#transfer-http]]] documents that define how [=Transfer Processes=] using a given [=Data Transfer Protocol=] are governed via HTTPS endpoints.

--- a/specifications/common/scope.md
+++ b/specifications/common/scope.md
@@ -9,4 +9,4 @@ This document gives guidance of how this metadata is provisioned:
 * This document specifies how [=Agreements=] that govern data usage are syntactically expressed and electronically negotiated during a [=Contract Negotiation=].
 * This document specifies how [=Datasets=] are accessed using [=Transfer Process Protocols=].
 
-This document does not apply to the data transfer protocol.
+This document does not apply to the [=Data Transfer Protocol=].

--- a/specifications/common/terminology.md
+++ b/specifications/common/terminology.md
@@ -46,6 +46,10 @@ A set of technical services that facilitate interoperable [=Dataset=] sharing be
 
 A set of [=Messages=] and [=Message=] sequences that enables the interaction between [=Participant Agents=] in a [=Dataspace=]. This may require additional concepts, which are not in the scope of the specifications themselves.
 
+<dfn>Data Transfer Protocol</dfn>
+
+A set of rules and conventions that dictate how data is transmitted over a network by defining the format, error handling, and flow control. Examples include HTTP, FTP, MQTT, and AMQP.
+
 <dfn>Message</dfn>
 
 An instantiation of a [=Message Type=].


### PR DESCRIPTION
## What this PR changes/adds

Adds "data transfer protocol" to terms and definitions.

## Why it does that

Increase the comprehensibility of the documents by explaining used terms. Emphasize the delimitation of the DSP from the data layer.

## Linked Issue(s)

Closes #132

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._