### PR TITLE
feat: change duty from single element to array

### DIFF
--- a/artifacts/src/main/resources/catalog/example/catalog.json
+++ b/artifacts/src/main/resources/catalog/example/catalog.json
@@ -30,9 +30,11 @@
                   "rightOperand": "http://example.org/EU"
                 }
               ],
-              "duty": {
-                "action": "Attribution"
-              }
+              "duty": [
+                {
+                  "action": "Attribution"
+                }
+              ]
             }
           ]
         }

--- a/artifacts/src/main/resources/context/odrl.jsonld
+++ b/artifacts/src/main/resources/context/odrl.jsonld
@@ -55,7 +55,8 @@
     "Duty": "odrl:Duty",
     "duty": {
       "@type": "@id",
-      "@id": "odrl:duty"
+      "@id": "odrl:duty",
+      "@container": "@set"
     },
     "Constraint": "odrl:Constraint",
     "constraint": {

--- a/artifacts/src/main/resources/negotiation/contract-schema.json
+++ b/artifacts/src/main/resources/negotiation/contract-schema.json
@@ -166,7 +166,10 @@
           }
         },
         "duty": {
-          "$ref": "#/definitions/Duty"
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Duty"
+          }
         }
       },
       "required": [

--- a/artifacts/src/main/resources/negotiation/example/contract-agreement-message-full.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-agreement-message-full.json
@@ -71,16 +71,18 @@
             "rightOperand": "gold"
           }
         ],
-        "duty": {
-          "action": "report",
-          "constraint": [
-            {
-              "leftOperand": "event",
-              "operator": "gt",
-              "rightOperand": "use"
-            }
-          ]
-        }
+        "duty": [
+          {
+            "action": "report",
+            "constraint": [
+              {
+                "leftOperand": "event",
+                "operator": "gt",
+                "rightOperand": "use"
+              }
+            ]
+          }
+        ]
       },
       {
         "action": "use",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/PolicySchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/PolicySchemaTest.java
@@ -54,9 +54,9 @@ public class PolicySchemaTest extends AbstractSchemaTest {
                     "operator": "eq",
                     "rightOperand": "gold"
                   }],
-                  "duty": {
+                  "duty": [{
                     "action": "report"
-                  }
+                  }]
                 }
               ]
             }""";
@@ -75,9 +75,9 @@ public class PolicySchemaTest extends AbstractSchemaTest {
                       "operator": "eq",
                       "rightOperand": "gold"
                   }],
-                  "duty": {
+                  "duty": [{
                     "action": "report"
-                  }
+                  }]
                 }
               ]
             }""";
@@ -96,9 +96,9 @@ public class PolicySchemaTest extends AbstractSchemaTest {
                       "operator": "eq",
                       "rightOperand": "gold"
                   }],
-                  "duty": {
+                  "duty": [{
                     "action": "report"
-                  }
+                  }]
                 }
               ]
             }""";
@@ -117,14 +117,14 @@ public class PolicySchemaTest extends AbstractSchemaTest {
                       "operator": "eq",
                       "rightOperand": "gold"
                   }],
-                  "duty": {
+                  "duty": [{
                     "action": "report",
                     "constraint": [{
                           "leftOperand": "event",
                           "operator": "gt",
                           "rightOperand": "use"
                     }]
-                  }
+                  }]
                 }
               ]
             }""";


### PR DESCRIPTION
## What this PR changes/adds

Changes `duty` property to be always an array.

## Why it does that

Allow flexibility with respect to ODRL policies.

## Linked Issue(s)

Closes #157 
