### PR TITLE
fix: remove duplicate id property on DataService

### DIFF
--- a/artifacts/src/main/resources/catalog/dataset-schema.json
+++ b/artifacts/src/main/resources/catalog/dataset-schema.json
@@ -111,9 +111,6 @@
         },
         {
           "properties": {
-            "@id": {
-              "type": "string"
-            },
             "@type": {
               "type": "string",
               "const": "DataService"
@@ -130,7 +127,6 @@
             }
           },
           "required": [
-            "@id",
             "@type",
             "endpointURL"
           ]


### PR DESCRIPTION
## What this PR changes/adds

remove the duplicate `@id` property

## Why it does that

redundancy removal

## Further notes

build succeeds locally
![image](https://github.com/user-attachments/assets/b51745b8-522b-4995-9905-5452d343bb5c)


## Linked Issue(s)

Closes #140

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._