### PR TITLE
feat: restrict contract request message to object

### DIFF
--- a/artifacts/src/main/resources/negotiation/contract-request-message-schema.json
+++ b/artifacts/src/main/resources/negotiation/contract-request-message-schema.json
@@ -26,35 +26,7 @@
           "type": "string"
         },
         "offer": {
-          "oneOf": [
-            {
-              "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/MessageOffer"
-            },
-            {
-              "properties": {
-                "@id": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "@id"
-              ],
-              "not": {
-                "anyOf": [
-                  {
-                    "required": [
-                      "permission"
-                    ]
-                  },
-                  {
-                    "required": [
-                      "prohibition"
-                    ]
-                  }
-                ]
-              }
-            }
-          ]
+          "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/MessageOffer"
         },
         "callbackAddress": {
           "type": "string",

--- a/artifacts/src/main/resources/negotiation/contract-schema.json
+++ b/artifacts/src/main/resources/negotiation/contract-schema.json
@@ -69,6 +69,9 @@
             "@type": {
               "type": "string",
               "const": "Offer"
+            },
+            "target": {
+              "type": "string"
             }
           }
         },
@@ -95,7 +98,29 @@
       "type": "object",
       "allOf": [
         {
-          "$ref": "#/definitions/MessageOffer"
+          "$ref": "#/definitions/PolicyClass"
+        },
+        {
+          "properties": {
+            "@type": {
+              "type": "string",
+              "const": "Offer"
+            }
+          }
+        },
+        {
+          "anyOf": [
+            {
+              "required": [
+                "permission"
+              ]
+            },
+            {
+              "required": [
+                "prohibition"
+              ]
+            }
+          ]
         }
       ],
       "not": {

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/ContractRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/ContractRequestMessageSchemaTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static com.networknt.schema.InputFormat.JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ContractRequestMessageSchemaTest extends AbstractSchemaTest {
@@ -37,43 +36,9 @@ public class ContractRequestMessageSchemaTest extends AbstractSchemaTest {
         assertThat(schema.validate(node)).isEmpty();
     }
 
-    @Test
-    void verifyIdRequest() {
-        assertThat(schema.validate(REQUEST_ID, JSON)).isEmpty();
-        assertThat(schema.validate(REQUEST_INITIAL_ID, JSON)).isEmpty();
-    }
-
     @BeforeEach
     void setUp() {
         setUp("/negotiation/contract-request-message-schema.json");
     }
 
-    private static final String REQUEST_ID = """
-            {
-                "@context": [
-                  "https://w3id.org/dspace/2025/1/context.jsonld"
-                ],
-                "@type": "ContractRequestMessage",
-                "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
-                "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
-                "offer": {
-                  "@id": "urn:uuid:d526561f-528e-4d5a-ae12-9a9dd9b7a815"
-                },
-                "callbackAddress": "https://example.com/callback"
-            }
-            """;
-
-    private static final String REQUEST_INITIAL_ID = """
-            {
-                "@context": [
-                  "https://w3id.org/dspace/2025/1/context.jsonld"
-                ],
-                "@type": "ContractRequestMessage",
-                "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
-                "offer": {
-                  "@id": "urn:uuid:d526561f-528e-4d5a-ae12-9a9dd9b7a815"
-                },
-                "callbackAddress": "https://example.com/callback"
-            }
-            """;
 }

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/InvalidContractRequestMessageSchemaTest.java
@@ -26,11 +26,12 @@ public class InvalidContractRequestMessageSchemaTest extends AbstractSchemaTest 
     @Test
     void verifyInvalidCases() {
         assertThat(schema.validate(INVALID_REQUEST_NO_OFFER, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
-        assertThat(schema.validate(INVALID_REQUEST_NO_ID, JSON).iterator().next().getType()).isEqualTo(ONE_OF);
+        assertThat(schema.validate(INVALID_REQUEST_NO_ID, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
         assertThat(schema.validate(INVALID_REQUEST_NO_CONSUMER_ID, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
         assertThat(schema.validate(INVALID_REQUEST_NO_CALLBACK, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
         assertThat(schema.validate(INVALID_REQUEST_NO_TYPE, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
         assertThat(schema.validate(INVALID_REQUEST_NO_CONTEXT, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
+        assertThat(schema.validate(INVALID_REQUEST_JUST_ID, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
     }
 
     @BeforeEach
@@ -106,6 +107,21 @@ public class InvalidContractRequestMessageSchemaTest extends AbstractSchemaTest 
     private static final String INVALID_REQUEST_NO_CONTEXT = """
             {
                 "@type": "ContractRequestMessage",
+                "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
+                "offer": {
+                  "@id": "urn:uuid:d526561f-528e-4d5a-ae12-9a9dd9b7a815"
+                },
+                "callbackAddress": "https://example.com/callback"
+            }
+            """;
+
+    private static final String INVALID_REQUEST_JUST_ID = """
+            {
+                "@context": [
+                  "https://w3id.org/dspace/2025/1/context.jsonld"
+                ],
+                "@type": "ContractRequestMessage",
+                "providerPid": "urn:uuid:a343fcbf-99fc-4ce8-8e9b-148c97605aab",
                 "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
                 "offer": {
                   "@id": "urn:uuid:d526561f-528e-4d5a-ae12-9a9dd9b7a815"

--- a/specifications/negotiation/contract.negotiation.binding.https.md
+++ b/specifications/negotiation/contract.negotiation.binding.https.md
@@ -89,7 +89,7 @@ to `negotiations/request`:
 <aside class="example" title="Contract Request">
     <pre class="http">POST https://provider.com/negotiations/request
 Authorization: ...</pre>
-    <pre class="json" data-include="message/example/contract-request-message.json">
+    <pre class="json" data-include="message/example/contract-request-message_initial.json">
     </pre>
 </aside>
 
@@ -252,7 +252,7 @@ a [Contract Offer Message](#contract-offer-message) to `negotiations/offers`:
 <aside class="example" title="Contract Offer Request">
     <pre class="http">POST https://consumer.com/negotiations/offers
 Authorization: ...</pre>
-    <pre class="json" data-include="message/example/contract-offer-message.json">
+    <pre class="json" data-include="message/example/contract-offer-message_initial.json">
     </pre>
 </aside>
 

--- a/specifications/negotiation/contract.negotiation.protocol.md
+++ b/specifications/negotiation/contract.negotiation.protocol.md
@@ -71,6 +71,7 @@ a [Contract Offer Message](#contract-offer-message) sent by a [=Provider=].
   an appropriate `providerPid`.
 - An `offer.@id` will generally refer to an [=Offer=] contained in a [=Catalog=]. If the [=Provider=] is not aware of
   the `offer.@id` value, it must respond with an error message.
+- `offer.obligation` and `offer.permission` signify the terms at which a [=Consumer=] would accept an [=Offer=]. 
 - The `callbackAddress` is a URL indicating where messages to the [=Consumer=] should be sent in asynchronous settings.
   If the address is not understood, the [=Provider=] MUST return an UNRECOVERABLE error.
 - Different to a [=Catalog=] or [=Dataset=], the [=Offer=] inside


### PR DESCRIPTION
## What this PR changes/adds

This PR narrows down the allowed data structure in the `offer` property of the `ContractRequestMessage`

## Why it does that

A client has no way of knowing if a provider's ParticipantAgent requires a policy of just the id advertised in the catalog. That's why the Consumer must always give the full object anyway.

## Further notes

How a Provider handles the message is outside the scope of the spec.

## Linked Issue(s)

Closes #142 

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._