### PR TITLE
feat: Make `DataAddress.endpoint` property optional

### DIFF
--- a/artifacts/src/main/resources/transfer/data-address-schema.json
+++ b/artifacts/src/main/resources/transfer/data-address-schema.json
@@ -32,8 +32,7 @@
       },
       "required": [
         "@type",
-        "endpointType",
-        "endpoint"
+        "endpointType"
       ]
     },
     "EndpointProperty": {

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/InvalidTransferRequestMessageSchemaTest.java
@@ -34,7 +34,6 @@ public class InvalidTransferRequestMessageSchemaTest extends AbstractSchemaTest 
 
         assertThat(schema.validate(INVALID_NO_DA_TYPE, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
         assertThat(schema.validate(INVALID_NO_DA_ENDPOINT_TYPE, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
-        assertThat(schema.validate(INVALID_NO_DA_ENDPOINT, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
     }
 
     @BeforeEach
@@ -141,23 +140,6 @@ public class InvalidTransferRequestMessageSchemaTest extends AbstractSchemaTest 
               "dataAddress": {
                 "@type": "DataAddress",
                 "endpoint": "http://example.com"
-              },
-              "callbackAddress": "https://example.com/callback"
-            }
-            """;
-
-    private static final String INVALID_NO_DA_ENDPOINT = """
-            {
-              "@context": [
-                "https://w3id.org/dspace/2025/1/context.jsonld"
-              ],
-              "@type": "TransferRequestMessage",
-              "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
-              "agreementId": "urn:uuid:e8dc8655-44c2-46ef-b701-4cffdc2faa44",
-              "format": "example:HTTP_PUSH",
-              "dataAddress": {
-                "@type": "DataAddress",
-                "endpointType": "https://w3id.org/idsa/v4.1/HTTP"
               },
               "callbackAddress": "https://example.com/callback"
             }

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/TransferRequestMessageSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/transfer/TransferRequestMessageSchemaTest.java
@@ -34,6 +34,7 @@ public class TransferRequestMessageSchemaTest extends AbstractSchemaTest {
     @Test
     void verifyMinimalRequestSchema() {
         assertThat(schema.validate(MINIMAL_REQUEST, JSON)).isEmpty();
+        assertThat(schema.validate(NO_DA_ENDPOINT, JSON)).isEmpty();
     }
 
     @BeforeEach
@@ -50,6 +51,23 @@ public class TransferRequestMessageSchemaTest extends AbstractSchemaTest {
               "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
               "agreementId": "urn:uuid:e8dc8655-44c2-46ef-b701-4cffdc2faa44",
               "format": "example:HTTP_PUSH",
+              "callbackAddress": "https://example.com/callback"
+            }
+            """;
+
+    private static final String NO_DA_ENDPOINT = """
+            {
+              "@context": [
+                "https://w3id.org/dspace/2025/1/context.jsonld"
+              ],
+              "@type": "TransferRequestMessage",
+              "consumerPid": "urn:uuid:32541fe6-c580-409e-85a8-8a9a32fbe833",
+              "agreementId": "urn:uuid:e8dc8655-44c2-46ef-b701-4cffdc2faa44",
+              "format": "example:HTTP_PUSH",
+              "dataAddress": {
+                "@type": "DataAddress",
+                "endpointType": "https://w3id.org/idsa/v4.1/HTTP"
+              },
               "callbackAddress": "https://example.com/callback"
             }
             """;


### PR DESCRIPTION
## What this PR changes/adds

Makes the `DataAddress.endpoint` property optional.


## Linked Issue(s)

Closes #156

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._