### PR TITLE
chore: enumerate dsp-versions

### DIFF
--- a/artifacts/src/main/resources/common/protocol-version-schema.json
+++ b/artifacts/src/main/resources/common/protocol-version-schema.json
@@ -28,7 +28,19 @@
       "type": "object",
       "properties": {
         "version": {
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string",
+              "enum": [
+                "0.8",
+                "2024-1",
+                "2025-1"
+              ]
+            }
+          ]
         },
         "path": {
           "type": "string"


### PR DESCRIPTION
## What this PR changes/adds

Outlines how published DSP versions should be referred to in the version endpoint.

## Why it does that

consistency 

## Further notes

for forward compatibility with future versions, see issue

Closes #152

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._