### PR TITLE
chore: elaborate on json-ld context extension

### DIFF
--- a/specifications/common/common.protocol.md
+++ b/specifications/common/common.protocol.md
@@ -14,7 +14,7 @@ JSON-LD context is designed to produce [=Message=] serializations using compacti
 for the given [=Message=] type. This allows implementations to choose whether to process [=Messages=] as plain JSON or
 as JSON-LD and maintain interoperability between those approaches. Profiles that use JSON-LD are encouraged to provide
 similar contexts that facilitate this approach to interoperability. As this specification's JSON-LD objects are 
-`@protected`, profiles must not be combined such that they override each other's term definitions.
+`@protected`, profile authors are advised to define their custom terms as protected to spot term redefinition early.
 
 ## Exposure of Versions {#exposure-of-dataspace-protocol-versions}
 

--- a/specifications/common/common.protocol.md
+++ b/specifications/common/common.protocol.md
@@ -12,8 +12,9 @@ All protocol [=Messages=] are normatively defined by a [[json-schema]]. This spe
 provides a JSON-LD context to serialize data structures and [=Message=] types as it facilitates extensibility. The
 JSON-LD context is designed to produce [=Message=] serializations using compaction that validate against the Json Schema
 for the given [=Message=] type. This allows implementations to choose whether to process [=Messages=] as plain JSON or
-as JSON-LD and maintain interoperability between those approaches. Extensions that use JSON-LD are encouraged to provide
-similar contexts that facilitate this approach to interoperability.
+as JSON-LD and maintain interoperability between those approaches. Profiles that use JSON-LD are encouraged to provide
+similar contexts that facilitate this approach to interoperability. As this specification's JSON-LD objects are 
+`@protected`, profiles must not be combined such that they override each other's term definitions.
 
 ## Exposure of Versions {#exposure-of-dataspace-protocol-versions}
 


### PR DESCRIPTION
## What this PR changes/adds

This PR notes the possibility for term collisions between profiles.

## Why it does that

There's a non-trivial risk of DSP-profiles defining terms resolving to diverging URIs. This is alluded to in the spec and will be elaborated in the best practices.

## Linked Issue(s)

Closes #158

Created follow-up in best practices: https://github.com/eclipse-dataspace-protocol-base/dsp_best_practices/issues/17
