### PR TITLE
fix: refactor catalog-adjacent schemas

### DIFF
--- a/artifacts/src/main/resources/catalog/catalog-schema.json
+++ b/artifacts/src/main/resources/catalog/catalog-schema.json
@@ -33,7 +33,7 @@
       "type": "object",
       "allOf": [
         {
-          "$ref": "https://w3id.org/dspace/2025/1/catalog/dataset-schema.json#/definitions/AbstractDataset"
+          "$ref": "https://w3id.org/dspace/2025/1/catalog/dataset-schema.json#/definitions/Resource"
         },
         {
           "properties": {

--- a/artifacts/src/main/resources/catalog/dataset-schema.json
+++ b/artifacts/src/main/resources/catalog/dataset-schema.json
@@ -9,7 +9,7 @@
   ],
   "$id": "https://w3id.org/dspace/2025/1/catalog/dataset-schema.json",
   "definitions": {
-    "AbstractDataset": {
+    "Dataset": {
       "type": "object",
       "allOf": [
         {
@@ -32,14 +32,6 @@
               "minItems": 1
             }
           }
-        }
-      ]
-    },
-    "Dataset": {
-      "type": "object",
-      "allOf": [
-        {
-          "$ref": "#/definitions/AbstractDataset"
         }
       ],
       "required": [


### PR DESCRIPTION
## What this PR changes/adds

The catalog object currently has optional `hasPolicy` and `distribution` objects. There's no functional necessity for that. This removes it.

## Further notes

Removes the `AbstractDataset`

## Linked Issue(s)

Closes #139

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._