### PR TITLE
feat: add definition of Rule to schemas

### DIFF
--- a/artifacts/buildSrc/README.md
+++ b/artifacts/buildSrc/README.md
@@ -33,7 +33,7 @@ For example:
         <td></td>
     </tr>
     <tr>
-        <td class="code">permission</td>
+        <td class="code">rule</td>
         <td>array</td>
         <td></td>
     </tr>

--- a/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/jsom/TestSchema.java
+++ b/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/jsom/TestSchema.java
@@ -64,7 +64,14 @@ public interface TestSchema {
                     "permission": {
                       "type": "array",
                       "items": {
-                        "$ref": "#/definitions/Permission"
+                        "$ref": "#/definitions/Rule"
+                      },
+                      "minItems": 1
+                    },
+                    "prohibition": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Rule"
                       },
                       "minItems": 1
                     },
@@ -177,7 +184,7 @@ public interface TestSchema {
                     "assigner"
                   ]
                 },
-                "Permission": {
+                "Rule": {
                   "type": "object",
                   "properties": {
                     "action": {

--- a/artifacts/src/main/resources/negotiation/contract-schema.json
+++ b/artifacts/src/main/resources/negotiation/contract-schema.json
@@ -42,7 +42,14 @@
         "permission": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Permission"
+            "$ref": "#/definitions/Rule"
+          },
+          "minItems": 1
+        },
+        "prohibition": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Rule"
           },
           "minItems": 1
         },
@@ -178,7 +185,7 @@
         "assigner"
       ]
     },
-    "Permission": {
+    "Rule": {
       "type": "object",
       "properties": {
         "action": {

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/PolicySchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/PolicySchemaTest.java
@@ -29,6 +29,7 @@ public class PolicySchemaTest extends AbstractSchemaTest {
         assertThat(schema.validate(POLICY_STRING_PROFILE, JSON)).isEmpty();
         assertThat(schema.validate(POLICY_ARRAY_PROFILE, JSON)).isEmpty();
         assertThat(schema.validate(POLICY_PERMISSION_DUTY, JSON)).isEmpty();
+        assertThat(schema.validate(POLICY_PROHIBITION_DUTY, JSON)).isEmpty();
         assertThat(schema.validate(POLICY_OR_CONSTRAINT, JSON)).isEmpty();
         assertThat(schema.validate(POLICY_AND_CONSTRAINT, JSON)).isEmpty();
         assertThat(schema.validate(POLICY_AND_SEQUENCE_CONSTRAINT, JSON)).isEmpty();
@@ -110,6 +111,32 @@ public class PolicySchemaTest extends AbstractSchemaTest {
               "target": "asset:1",
               "profile": ["https://test.com/profile"],
               "permission": [
+                {
+                  "action": "use",
+                  "constraint": [{
+                      "leftOperand": "partner",
+                      "operator": "eq",
+                      "rightOperand": "gold"
+                  }],
+                  "duty": [{
+                    "action": "report",
+                    "constraint": [{
+                          "leftOperand": "event",
+                          "operator": "gt",
+                          "rightOperand": "use"
+                    }]
+                  }]
+                }
+              ]
+            }""";
+
+    private static final String POLICY_PROHIBITION_DUTY = """
+            {
+              "@id": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
+              "@type": "Offer",
+              "target": "asset:1",
+              "profile": ["https://test.com/profile"],
+              "prohibition": [
                 {
                   "action": "use",
                   "constraint": [{

--- a/specifications/common/type.definitions.md
+++ b/specifications/common/type.definitions.md
@@ -36,7 +36,7 @@
 <p data-include="message/table/offer.html" data-include-format="html">
 </p>
 
-<p data-include="message/table/permission.html" data-include-format="html">
+<p data-include="message/table/rule.html" data-include-format="html">
 </p>
 
 <p data-include="message/table/versionresponse.html" data-include-format="html">


### PR DESCRIPTION
## What this PR changes/adds

Adds definition of prohibition to schemas. Unifies `permission` and `prohibition` to `Rule`.

## Why it does that

Prohibitions objects are not modelled in the JSON schemas, but are referenced as properties.

## Further notes

--

## Linked Issue(s)

Closes #162

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._