### PR TITLE
chore: publish RC2

### DIFF
--- a/.github/scripts/index.html
+++ b/.github/scripts/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="refresh"
-          content="0;url=https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC1"/>
-    <link rel="canonical" href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC1"/>
+          content="0;url=https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC2"/>
+    <link rel="canonical" href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC2"/>
 </head>
 <body>
 <h4>
-    This redirects to the latest Release Candidate <a href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC1">here</a>
+    This redirects to the latest Release Candidate <a href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC2">here</a>
 </h4>
 </body>
 </html>

--- a/WEBSITE.md
+++ b/WEBSITE.md
@@ -28,3 +28,35 @@ be easy.
 1. Locally execute the commands from the [autopublish](.github/workflows/autopublish.yaml) workflow's "Copy files for correct web access" step. All resulting folders and files are duplicates, gitignored and don't break anything.
 2. Open the `index.html` file.
 3. You IDE should have a feature to display html documents (either in your browser of choice or inline). Use that and you should always see the updated webpage when saving.
+
+### Publishing versions
+
+When wanting to pin and publish a snapshot in time via a separate url-path, follow the appropriate steps listed below.
+
+#### Prep commits
+
+When the content is finished, a release requires a first commit with
+
+1. a tag with the exact version string (like `2025-1-RC1`) on the release commit
+2. to change the redirect in `.github/scripts/index.html` to point to latest release candidate
+3. set the `respecConfig.publishDate` in `index.html` to a string like `"2025-02-27"`,`
+4. set the `respecConfig.specStatus` in `index.html` to `base`
+
+In case of versions with a new namespace, additionally:
+
+5. adjust the textual description of the context URI in the base spec
+6. appended w3id referrals
+
+and then (independently of major/minor) a second commit
+
+1. setting the specStatus config option to `unofficial` and
+2. increase the spec version in the title of `index.html`
+3. remove the release date
+
+#### Push and build
+
+- Open a PR with both commits. Wait for it to be merged.
+- Push the tag to origin/main on Github.
+- Rerun the actions.
+
+You should now see an additional endpoint at `https://eclipse-dataspace-dcp.github.io/decentralized-claims-protocol/my-version-tag/`.

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <script class="remove" src="https://cdn.jsdelivr.net/gh/w3c/respec-mermaid@1.1.0/dist/main.js"></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: "base",
+            specStatus: "unofficial",
             latestVersion: "https://docs.internationaldataspaces.org/ids-knowledgebase/dataspace-protocol",
             editors: [{
                name: "Sebastian Steinbuss",
@@ -14,7 +14,6 @@
                company: "International Data Spaces Association",
                companyURL: "https://internationaldataspaces.org/",
             }],
-            publishDate: "2025-06-19",
             authors: [
                 {
                   name: "Peter Koen",
@@ -62,13 +61,13 @@
             maxTocLevel: 3,
         };
     </script>
-    <title>Dataspace Protocol Release 2025-1-RC2</title>
+    <title>Dataspace Protocol Release 2025-1-RC3</title>
 </head>
 <body>
 <p class="copyright">
     This document is licensed under <a href="https://www.apache.org/licenses/LICENSE-2.0.html">The Apache License, Version 2.0</a>.
 </p>
-<h1 id="title">Dataspace Protocol 2025-1-RC2</h1>
+<h1 id="title">Dataspace Protocol 2025-1-RC3</h1>
 <section id='abstract'>
     <p>
         The Dataspace Protocol is a set of specifications designed to facilitate interoperable data sharing between

--- a/index.html
+++ b/index.html
@@ -6,14 +6,15 @@
     <script class="remove" src="https://cdn.jsdelivr.net/gh/w3c/respec-mermaid@1.1.0/dist/main.js"></script>
     <script class='remove'>
         var respecConfig = {
-          specStatus: "unofficial",
-          latestVersion: "https://docs.internationaldataspaces.org/ids-knowledgebase/dataspace-protocol",
-          editors: [{
-              name: "Sebastian Steinbuss",
-              url: "https://github.com/ssteinbuss",
-              company: "International Data Spaces Association",
-              companyURL: "https://internationaldataspaces.org/",
-          }],
+            specStatus: "base",
+            latestVersion: "https://docs.internationaldataspaces.org/ids-knowledgebase/dataspace-protocol",
+            editors: [{
+               name: "Sebastian Steinbuss",
+               url: "https://github.com/ssteinbuss",
+               company: "International Data Spaces Association",
+               companyURL: "https://internationaldataspaces.org/",
+            }],
+            publishDate: "2025-06-19",
             authors: [
                 {
                   name: "Peter Koen",
@@ -48,17 +49,17 @@
                 {
                   name: "Arno Weiß",
                   url: "https://github.com/arnoweiss",
-                  company: "SAP"
+                  company: "SAP SE"
                 },
               ],
-          github: {
-            branch: "main",
-            repoURL: "eclipse-dataspace-protocol-base/DataspaceProtocol",
-          },
-          xref: "web-platform",
-          lint: { "no-unused-dfns": false, "local-refs-exist": true },
-          format: "markdown",
-          maxTocLevel: 3,
+            github: {
+              branch: "main",
+              repoURL: "eclipse-dataspace-protocol-base/DataspaceProtocol",
+            },
+            xref: "web-platform",
+            lint: { "no-unused-dfns": false, "local-refs-exist": true },
+            format: "markdown",
+            maxTocLevel: 3,
         };
     </script>
     <title>Dataspace Protocol Release 2025-1-RC2</title>


### PR DESCRIPTION
## What this PR changes/adds

Publish the second release candidate for review.

## Additional Notes
🛑**do not squash on merge**🛑

After merge, commit https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol/commit/6f8dd0c2ab013b0e78cca74fd1938507b838aa06 requires a tag `2025-1-RC2` via direct push to main by a committer.

## Linked Issue(s)

Closes #182 

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._