### PR TITLE
feat: add signal for participant identification

### DIFF
--- a/artifacts/src/main/resources/common/example/protocol-version.json
+++ b/artifacts/src/main/resources/common/example/protocol-version.json
@@ -4,7 +4,8 @@
       "version": "2025-1",
       "path": "/some/path/2025-1",
       "binding": "HTTPS",
-      "serviceId": "service-asdf"
+      "serviceId": "service-asdf",
+      "identification": "did:web"
     },
     {
       "version": "2024-1",
@@ -18,7 +19,8 @@
           "refresh_token"
         ]
       },
-      "serviceId": "service-asdf"
+      "serviceId": "service-asdf",
+      "identification": "D-U-N-S"
 
     },
     {

--- a/artifacts/src/main/resources/common/example/protocol-version.json
+++ b/artifacts/src/main/resources/common/example/protocol-version.json
@@ -5,7 +5,7 @@
       "path": "/some/path/2025-1",
       "binding": "HTTPS",
       "serviceId": "service-asdf",
-      "identification": "did:web"
+      "identifierType": "did:web"
     },
     {
       "version": "2024-1",
@@ -20,7 +20,7 @@
         ]
       },
       "serviceId": "service-asdf",
-      "identification": "D-U-N-S"
+      "identifierType": "D-U-N-S"
 
     },
     {

--- a/artifacts/src/main/resources/common/protocol-version-schema.json
+++ b/artifacts/src/main/resources/common/protocol-version-schema.json
@@ -51,6 +51,9 @@
             "HTTPS"
           ]
         },
+        "identification": {
+          "type": "string"
+        },
         "serviceId": {
           "type": "string"
         },

--- a/artifacts/src/main/resources/common/protocol-version-schema.json
+++ b/artifacts/src/main/resources/common/protocol-version-schema.json
@@ -51,7 +51,7 @@
             "HTTPS"
           ]
         },
-        "identification": {
+        "identifierType": {
           "type": "string"
         },
         "serviceId": {

--- a/specifications/common/common.protocol.md
+++ b/specifications/common/common.protocol.md
@@ -32,7 +32,7 @@ with at least one item.
 The item connects the version tag (`version` attribute) with a path to the endpoint.
 The semantics of the `path` property are specified by each protocol binding. The `serviceId` is a unique id for 
 a [=Data Service=] and allows to group DSP-endpoints exposed by different [=Data Service=]s across versions. `binding`
-describes the DSP protocol binding such as HTTPS. `identification` describes the type of identifier used to refer to
+describes the DSP protocol binding such as HTTPS. `identifierType` describes the type of identifier used to refer to
 participants in the protocol communication.
 
 <p data-include="message/table/version.html" data-include-format="html">

--- a/specifications/common/common.protocol.md
+++ b/specifications/common/common.protocol.md
@@ -24,11 +24,26 @@ must provide a version metadata endpoint ending with URI segments `/.well-known/
 endpoint should adhere to [[rfc8615]].
 
 A [=Connector=] must respond to a respective HTTPS request by returning a [`VersionResponse`](#VersionResponse-table)
-with at least one item. The item connects the version tag (`version` attribute) with a path to the endpoint.
+with at least one item. 
+
+<p data-include="message/table/versionresponse.html" data-include-format="html">
+</p>
+
+The item connects the version tag (`version` attribute) with a path to the endpoint.
 The semantics of the `path` property are specified by each protocol binding. The `serviceId` is a unique id for 
 a [=Data Service=] and allows to group DSP-endpoints exposed by different [=Data Service=]s across versions. `binding`
-describes the DSP protocol binding such as HTTPS. `auth` describes how a DSP endpoint is secured by means of the 
-`protocol`, `version` strings and the `profile` array.
+describes the DSP protocol binding such as HTTPS. `identification` describes the type of identifier used to refer to
+participants in the protocol communication.
+
+<p data-include="message/table/version.html" data-include-format="html">
+</p>
+
+`auth` describes how a DSP endpoint is secured by means of the `protocol`, `version` strings and the `profile` array.
+
+
+<p data-include="message/table/auth.html" data-include-format="html">
+</p>
+
 
 This data object must comply to the [JSON Schema](message/schema/protocol-version-schema.json). The requesting
 [=Connector=] may select from the endpoints in the response. If the [=Connector=] can't identify a matching Dataspace

--- a/specifications/common/type.definitions.md
+++ b/specifications/common/type.definitions.md
@@ -3,9 +3,6 @@
 <p data-include="message/table/action.html" data-include-format="html">
 </p>
 
-<p data-include="message/table/auth.html" data-include-format="html">
-</p>
-
 <p data-include="message/table/agreement.html" data-include-format="html">
 </p>
 
@@ -37,10 +34,4 @@
 </p>
 
 <p data-include="message/table/rule.html" data-include-format="html">
-</p>
-
-<p data-include="message/table/versionresponse.html" data-include-format="html">
-</p>
-
-<p data-include="message/table/version.html" data-include-format="html">
 </p>


### PR DESCRIPTION
## What this PR changes/adds

adds an additional property to the versions document to signify the type of id participants go by.

## Why it does that

Participants must know before initiating communication how to refer to one another. The base spec only defines the `participantId`, `assigner` and `assignee` properties as strings. Profiles must build on top of that

## Linked Issue(s)

Closes #166
