### PR TITLE
fix: remove `Duty` type properties

### DIFF
--- a/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/jsom/TestSchema.java
+++ b/artifacts/buildSrc/src/test/java/org/eclipse/dsp/generation/jsom/TestSchema.java
@@ -195,9 +195,6 @@ public interface TestSchema {
                       "items": {
                         "$ref": "#/definitions/Constraint"
                       }
-                    },
-                    "duty": {
-                      "$ref": "#/definitions/Duty"
                     }
                   },
                   "required": [

--- a/artifacts/src/main/resources/catalog/example/catalog.json
+++ b/artifacts/src/main/resources/catalog/example/catalog.json
@@ -29,11 +29,6 @@
                   "operator": "eq",
                   "rightOperand": "http://example.org/EU"
                 }
-              ],
-              "duty": [
-                {
-                  "action": "Attribution"
-                }
               ]
             }
           ]

--- a/artifacts/src/main/resources/negotiation/contract-schema.json
+++ b/artifacts/src/main/resources/negotiation/contract-schema.json
@@ -208,15 +208,7 @@
         {
           "$ref": "#/definitions/Rule"
         }
-      ],
-      "properties": {
-        "duty": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Duty"
-          }
-        }
-      }
+      ]
     },
     "Prohibition": {
       "type": "object",
@@ -224,15 +216,7 @@
         {
           "$ref": "#/definitions/Rule"
         }
-      ],
-      "properties": {
-        "remedy": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Duty"
-          }
-        }
-      }
+      ]
     },
     "Duty": {
       "type": "object",
@@ -246,12 +230,6 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/Constraint"
-              }
-            },
-            "consequence": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Duty"
               }
             }
           },

--- a/artifacts/src/main/resources/negotiation/contract-schema.json
+++ b/artifacts/src/main/resources/negotiation/contract-schema.json
@@ -42,14 +42,14 @@
         "permission": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Rule"
+            "$ref": "#/definitions/Permission"
           },
           "minItems": 1
         },
         "prohibition": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Rule"
+            "$ref": "#/definitions/Prohibition"
           },
           "minItems": 1
         },
@@ -196,17 +196,43 @@
           "items": {
             "$ref": "#/definitions/Constraint"
           }
-        },
+        }
+      },
+      "required": [
+        "action"
+      ]
+    },
+    "Permission": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Rule"
+        }
+      ],
+      "properties": {
         "duty": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Duty"
           }
         }
-      },
-      "required": [
-        "action"
-      ]
+      }
+    },
+    "Prohibition": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Rule"
+        }
+      ],
+      "properties": {
+        "remedy": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Duty"
+          }
+        }
+      }
     },
     "Duty": {
       "type": "object",
@@ -220,6 +246,12 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/Constraint"
+              }
+            },
+            "consequence": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Duty"
               }
             }
           },

--- a/artifacts/src/main/resources/negotiation/example/contract-agreement-message-full.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-agreement-message-full.json
@@ -70,18 +70,6 @@
             "operator": "eq",
             "rightOperand": "gold"
           }
-        ],
-        "duty": [
-          {
-            "action": "report",
-            "constraint": [
-              {
-                "leftOperand": "event",
-                "operator": "gt",
-                "rightOperand": "use"
-              }
-            ]
-          }
         ]
       },
       {

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/PolicySchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/PolicySchemaTest.java
@@ -144,7 +144,7 @@ public class PolicySchemaTest extends AbstractSchemaTest {
                       "operator": "eq",
                       "rightOperand": "gold"
                   }],
-                  "duty": [{
+                  "remedy": [{
                     "action": "report",
                     "constraint": [{
                           "leftOperand": "event",

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/PolicySchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/negotiation/PolicySchemaTest.java
@@ -29,7 +29,6 @@ public class PolicySchemaTest extends AbstractSchemaTest {
         assertThat(schema.validate(POLICY_STRING_PROFILE, JSON)).isEmpty();
         assertThat(schema.validate(POLICY_ARRAY_PROFILE, JSON)).isEmpty();
         assertThat(schema.validate(POLICY_PERMISSION_DUTY, JSON)).isEmpty();
-        assertThat(schema.validate(POLICY_PROHIBITION_DUTY, JSON)).isEmpty();
         assertThat(schema.validate(POLICY_OR_CONSTRAINT, JSON)).isEmpty();
         assertThat(schema.validate(POLICY_AND_CONSTRAINT, JSON)).isEmpty();
         assertThat(schema.validate(POLICY_AND_SEQUENCE_CONSTRAINT, JSON)).isEmpty();
@@ -54,9 +53,6 @@ public class PolicySchemaTest extends AbstractSchemaTest {
                     "leftOperand": "partner",
                     "operator": "eq",
                     "rightOperand": "gold"
-                  }],
-                  "duty": [{
-                    "action": "report"
                   }]
                 }
               ]
@@ -75,9 +71,6 @@ public class PolicySchemaTest extends AbstractSchemaTest {
                       "leftOperand": "partner",
                       "operator": "eq",
                       "rightOperand": "gold"
-                  }],
-                  "duty": [{
-                    "action": "report"
                   }]
                 }
               ]
@@ -96,9 +89,6 @@ public class PolicySchemaTest extends AbstractSchemaTest {
                       "leftOperand": "partner",
                       "operator": "eq",
                       "rightOperand": "gold"
-                  }],
-                  "duty": [{
-                    "action": "report"
                   }]
                 }
               ]
@@ -117,45 +107,10 @@ public class PolicySchemaTest extends AbstractSchemaTest {
                       "leftOperand": "partner",
                       "operator": "eq",
                       "rightOperand": "gold"
-                  }],
-                  "duty": [{
-                    "action": "report",
-                    "constraint": [{
-                          "leftOperand": "event",
-                          "operator": "gt",
-                          "rightOperand": "use"
-                    }]
                   }]
                 }
               ]
             }""";
-
-    private static final String POLICY_PROHIBITION_DUTY = """
-            {
-              "@id": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
-              "@type": "Offer",
-              "target": "asset:1",
-              "profile": ["https://test.com/profile"],
-              "prohibition": [
-                {
-                  "action": "use",
-                  "constraint": [{
-                      "leftOperand": "partner",
-                      "operator": "eq",
-                      "rightOperand": "gold"
-                  }],
-                  "remedy": [{
-                    "action": "report",
-                    "constraint": [{
-                          "leftOperand": "event",
-                          "operator": "gt",
-                          "rightOperand": "use"
-                    }]
-                  }]
-                }
-              ]
-            }""";
-
 
     private static final String POLICY_OR_CONSTRAINT = """
             {


### PR DESCRIPTION
## What this PR changes/adds

Fixes #198 and also reintroduces `Rule` subtypes back into the Json schema.

## Linked Issue(s)

Closes #198
