### PR TITLE
fix: invalid array string types

### DIFF
--- a/artifacts/src/main/resources/common/protocol-version-schema.json
+++ b/artifacts/src/main/resources/common/protocol-version-schema.json
@@ -78,7 +78,9 @@
         },
         "profile": {
           "type": "array",
-          "items": "string"
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [

--- a/artifacts/src/main/resources/negotiation/contract-schema.json
+++ b/artifacts/src/main/resources/negotiation/contract-schema.json
@@ -32,7 +32,9 @@
           "oneOf": [
             {
               "type": "array",
-              "items": "string"
+              "items": {
+                "type": "string"
+              }
             },
             {
               "type": "string"


### PR DESCRIPTION
## What this PR changes/adds

Fixes array schema definitions where `string` is used instead of a proper JSON schema type

## Why it does that

To be valid according to the 2019-09 JSON schema specification

## Further notes

Identified two files where this pattern was used and updated those.

## Linked Issue(s)

Closes #208

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._