### PR TITLE
fix: invalid schemas, test suite

### DIFF
--- a/artifacts/src/main/resources/common/protocol-version-schema.json
+++ b/artifacts/src/main/resources/common/protocol-version-schema.json
@@ -78,7 +78,9 @@
         },
         "profile": {
           "type": "array",
-          "items": "string"
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [

--- a/artifacts/src/main/resources/negotiation/contract-schema.json
+++ b/artifacts/src/main/resources/negotiation/contract-schema.json
@@ -32,7 +32,9 @@
           "oneOf": [
             {
               "type": "array",
-              "items": "string"
+              "items": {
+                "type": "string"
+              }
             },
             {
               "type": "string"

--- a/artifacts/src/test/java/org/eclipse/dsp/context/fixtures/AbstractJsonLdTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/context/fixtures/AbstractJsonLdTest.java
@@ -36,7 +36,7 @@ import java.util.Map;
 
 import static com.apicatalog.jsonld.JsonLd.compact;
 import static com.apicatalog.jsonld.JsonLd.expand;
-import static com.networknt.schema.SpecVersion.VersionFlag.V202012;
+import static com.networknt.schema.SpecVersion.VersionFlag.V201909;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dsp.DspConstants.DSP_CONTEXT;
@@ -61,7 +61,7 @@ public abstract class AbstractJsonLdTest {
             var expanded = expand(JsonDocument.of(message)).options(options).get();
             var compacted = compact(JsonDocument.of(expanded), JsonDocument.of(compactionContext)).options(options).get();
 
-            var schemaFactory = JsonSchemaFactory.getInstance(V202012, builder ->
+            var schemaFactory = JsonSchemaFactory.getInstance(V201909, builder ->
                     builder.schemaMappers(schemaMappers -> schemaMappers.mapPrefix(DSP_PREFIX, CLASSPATH_SCHEMA))
             );
 

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/common/InvalidVersionSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/common/InvalidVersionSchemaTest.java
@@ -37,6 +37,7 @@ public class InvalidVersionSchemaTest extends AbstractSchemaTest {
         assertThat(schema.validate(INVALID_AUTH_MISSING_PROTOCOL, JSON).iterator().next().getType()).isEqualTo(REQUIRED);
         assertThat(schema.validate(INVALID_AUTH_PROFILE_NOT_AN_ARRAY, JSON).iterator().next().getType()).isEqualTo(TYPE);
         assertThat(schema.validate(INVALID_SERVICEID_NOT_A_STRING, JSON).iterator().next().getType()).isEqualTo(TYPE);
+        assertThat(schema.validate(INVALID_AUTH_PROFILE_NOT_A_STRING, JSON).iterator().next().getType()).isEqualTo(TYPE);
     }
 
     @BeforeEach
@@ -160,12 +161,30 @@ public class InvalidVersionSchemaTest extends AbstractSchemaTest {
                   "version": "1.0",
                   "path": "/some/path/v1",
                   "binding": "HTTPS",
-                  "auth": [{
+                  "auth": {
                     "protocol": "some-protocol",
                     "version": "2",
-                    "profile": "one-profile"
-                  }],
+                    "profile": ["one-profile"]
+                  },
                   "serviceId": 666
+                }
+              ]
+            }
+            """;
+
+    private static final String INVALID_AUTH_PROFILE_NOT_A_STRING = """
+            {
+              "protocolVersions": [
+                {
+                  "version": "1.0",
+                  "path": "/some/path/v1",
+                  "binding": "HTTPS",
+                  "auth": {
+                    "protocol": "some-protocol",
+                    "version": "2",
+                    "profile": [666]
+                  },
+                  "serviceId": "some-uuid"
                 }
               ]
             }

--- a/artifacts/src/test/java/org/eclipse/dsp/schema/fixtures/AbstractSchemaTest.java
+++ b/artifacts/src/test/java/org/eclipse/dsp/schema/fixtures/AbstractSchemaTest.java
@@ -9,18 +9,25 @@
  *
  *  Contributors:
  *       Metaform Systems, Inc. - initial API and implementation
+ *       SAP SE - fixes
  *
  */
 
 package org.eclipse.dsp.schema.fixtures;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
 
-import static com.networknt.schema.SpecVersion.VersionFlag.V202012;
+import java.io.File;
+import java.io.IOException;
+
+import static com.networknt.schema.SchemaId.V201909;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dsp.DspConstants.DSP_PREFIX;
 
 /**
@@ -35,14 +42,28 @@ public abstract class AbstractSchemaTest {
     protected static final String ENUM = "enum";
 
     private static final String CLASSPATH_SCHEMA = "classpath:/";
+    private static final String MAIN_RESOURCES = "src/main/resources";
+
 
     protected ObjectMapper mapper = new ObjectMapper();
     protected JsonSchema schema;
+    protected JsonSchema metaSchema;
 
     protected void setUp(String schemaFile) {
-        var schemaFactory = JsonSchemaFactory.getInstance(V202012, builder ->
+        var schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909, builder ->
                 builder.schemaMappers(schemaMappers -> schemaMappers.mapPrefix(DSP_PREFIX, CLASSPATH_SCHEMA))
         );
+
+        metaSchema = schemaFactory.getSchema(SchemaLocation.of(V201909));
+
+        JsonNode schemaAsNode;
+        try {
+            schemaAsNode = mapper.readTree(new File(MAIN_RESOURCES + schemaFile));
+        } catch (IOException e) {
+            throw new RuntimeException();
+        }
+
+        assertThat(metaSchema.validate(schemaAsNode)).isEmpty();
 
         schema = schemaFactory.getSchema(SchemaLocation.of(DSP_PREFIX + schemaFile));
     }


### PR DESCRIPTION
## What this PR changes/adds

1. assert that json schemas comply to the meta schema
2. execute test suite on the meta schema release used in the schemas' `"$schema"` property (`"https://json-schema.org/draft/2019-09/schema"`)
3. fix two bugs in the schemas

## Why it does that

functional correctness

## Linked Issue(s)

Closes #208
Closes #210 
