### PR TITLE
fix: remove accidental references to W3C processes

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,8 @@
         of technical systems termed a Dataspace.
     </p>
 </section>
-<section id='sotd'>
+<section id='sotd'  class="override">
+    <h2>Status of this document</h2>
     <p>
         This version (2025-1) of the Dataspace Protocol specification is a release of the specification and considered to be
         stable. Further changes shall not affect conformity. All changes made to the specification can be reviewed in


### PR DESCRIPTION
## What this PR changes/adds

removes templated comments

## Why it does that

correctness wrt process

## Linked Issue(s)

Closes #214
