### PR TITLE
fix: remove assigner property from examples where appropriate

### DIFF
--- a/artifacts/src/main/resources/catalog/example/dataset.json
+++ b/artifacts/src/main/resources/catalog/example/dataset.json
@@ -8,7 +8,6 @@
     {
       "@type": "Offer",
       "@id": "urn:uuid:2828282:3dd1add8-4d2d-569e-d634-8394a8836a88",
-      "assigner": "http://example.com/Provider",
       "permission": [
         {
           "action": "use",

--- a/artifacts/src/main/resources/negotiation/example/contract-offer-message_initial.json
+++ b/artifacts/src/main/resources/negotiation/example/contract-offer-message_initial.json
@@ -7,7 +7,6 @@
   "offer": {
     "@type": "Offer",
     "@id": "urn:uuid:d526561f-528e-4d5a-ae12-9a9dd9b7a518",
-    "assigner": "urn:tsdshhs636378",
     "target": "urn:uuid:3dd1add8-4d2d-569e-d634-8394a8836a88",
     "permission": [
       {


### PR DESCRIPTION
## What this PR changes/adds

The PR removes two instances of the `assigner` property from examples where they're not in the schemas.

## Why it does that

consistency 

## Further notes

The schemas permit additional properties - that's why testing didn't catch this.

## Linked Issue(s)

Closes #213