### PR TITLE
fix: readd `distribution` to `Catalog`

### DIFF
--- a/artifacts/src/main/resources/catalog/catalog-schema.json
+++ b/artifacts/src/main/resources/catalog/catalog-schema.json
@@ -33,7 +33,7 @@
       "type": "object",
       "allOf": [
         {
-          "$ref": "https://w3id.org/dspace/2025/1/catalog/dataset-schema.json#/definitions/Resource"
+          "$ref": "https://w3id.org/dspace/2025/1/catalog/dataset-schema.json#/definitions/AbstractDataset"
         },
         {
           "properties": {

--- a/artifacts/src/main/resources/catalog/dataset-schema.json
+++ b/artifacts/src/main/resources/catalog/dataset-schema.json
@@ -17,13 +17,6 @@
         },
         {
           "properties": {
-            "hasPolicy": {
-              "type": "array",
-              "items": {
-                "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/Offer"
-              },
-              "minItems": 1
-            },
             "distribution": {
               "type": "array",
               "items": {
@@ -42,6 +35,15 @@
           "$ref": "#/definitions/AbstractDataset"
         }
       ],
+      "properties": {
+        "hasPolicy": {
+          "type": "array",
+          "items": {
+            "$ref": "https://w3id.org/dspace/2025/1/negotiation/contract-schema.json#/definitions/Offer"
+          },
+          "minItems": 1
+        }
+      },
       "required": [
         "hasPolicy",
         "distribution"

--- a/artifacts/src/main/resources/catalog/dataset-schema.json
+++ b/artifacts/src/main/resources/catalog/dataset-schema.json
@@ -9,7 +9,7 @@
   ],
   "$id": "https://w3id.org/dspace/2025/1/catalog/dataset-schema.json",
   "definitions": {
-    "Dataset": {
+    "AbstractDataset": {
       "type": "object",
       "allOf": [
         {
@@ -32,6 +32,14 @@
               "minItems": 1
             }
           }
+        }
+      ]
+    },
+    "Dataset": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AbstractDataset"
         }
       ],
       "required": [

--- a/specifications/catalog/catalog.protocol.md
+++ b/specifications/catalog/catalog.protocol.md
@@ -71,12 +71,12 @@ provided in protocol-dependent forms, e.g., for an HTTPS binding in the request 
 
 ### ACK - Dataset
 
-|                |                                                                               |
-|----------------|-------------------------------------------------------------------------------|
-| **Sent by**    | [=Provider=]                                                                  |
-| **Schema**     | [JSON Schema](message/schema/dataset-schema.json)                             |
-| **Example**    | [Dataset Example](message/example/dataset.json)                               |
-| **Properties**      | <p data-include="message/table/dataset.html" data-include-format="html"></p> |
+|                |                                                                                  |
+|----------------|----------------------------------------------------------------------------------|
+| **Sent by**    | [=Provider=]                                                                     |
+| **Schema**     | [JSON Schema](message/schema/dataset-schema.json)                                |
+| **Example**    | [Dataset Example](message/example/dataset.json)                                  |
+| **Properties**      | <p data-include="message/table/rootdataset.html" data-include-format="html"></p> |
 
 - A [=Dataset=] MUST have at least one `hasPolicy` attribute that contains an [=Offer=] defining the [=Policy=] associated with the [=Dataset=].
 

--- a/specifications/common/type.definitions.md
+++ b/specifications/common/type.definitions.md
@@ -12,6 +12,9 @@
 <p data-include="message/table/dataaddress.html" data-include-format="html">
 </p>
 
+<p data-include="message/table/dataset.html" data-include-format="html">
+</p>
+
 <p data-include="message/table/distribution.html" data-include-format="html">
 </p>
 


### PR DESCRIPTION
## What this PR changes/adds

Readds optional property previously erroneously removed

## Linked Issue(s)

Closes #219
