### PR TITLE
fix: textual link between Distribution and DataService

### DIFF
--- a/specifications/catalog/catalog.protocol.md
+++ b/specifications/catalog/catalog.protocol.md
@@ -82,7 +82,7 @@ provided in protocol-dependent forms, e.g., for an HTTPS binding in the request 
 
 - A [=Dataset=] MUST hold at least one `Distribution` object in the `distribution` attribute.
 
-- Each `DataService` object MUST have at least one `DataService` which specifies where the distribution is obtained. 
+- Each `Distribution` object MUST have at least one `DataService` which specifies where the distribution is obtained. 
   Specifically, a `DataService` specifies the endpoint for initiating a [=Contract Negotiation=] and [=Transfer Process=].
 
 - A `DataService.endpointURL` property contains the URL of the service the [=Contract Negotiation=] endpoints extend. The


### PR DESCRIPTION
## What this PR changes/adds

Fix an error in the textual description. [The schemas were correct ](https://[eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/message/schema/dataset-schema.json](https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/message/schema/dataset-schema.json))all along.

## Linked Issue(s)

Closes #235

_Please be sure to take a look at the [contributing guidelines](../CONTRIBUTING.md#submit-a-pull-request) and our [etiquette for pull requests](../PR_ETIQUETTE.md)._