### PR TITLE
fix(build): copy buildSrc from HEAD before building each tag

### DIFF
--- a/.github/scripts/checkout-tags.sh
+++ b/.github/scripts/checkout-tags.sh
@@ -22,6 +22,10 @@ for dir in */; do
   pwd
   ls -l
   if [ -f "$dir/index.html" ]; then
+      if [ "$dir" != "HEAD/" ]; then
+        rm -rf "$dir/artifacts/buildSrc"
+        cp -r HEAD/artifacts/buildSrc "$dir/artifacts/buildSrc"
+      fi
       cd "$dir/artifacts"
       ./gradlew build
       ./gradlew generateTablesFromSchemas


### PR DESCRIPTION
Copies `buildSrc` from HEAD into each tag directory before building, so all tags use the latest build tooling. Skips `HEAD/` itself.