### PR TITLE
fix(ci): correct table generation from schema definitions

### DIFF
--- a/.github/scripts/index.html
+++ b/.github/scripts/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="refresh"
-          content="0;url=https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1"/>
-    <link rel="canonical" href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1"/>
+          content="0;url=PAGES_REDIRECT_URL"/>
+    <link rel="canonical" href="PAGES_REDIRECT_URL"/>
 </head>
 <body>
 <h4>
-    This redirects to the latest Release Candidate <a href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1">here</a>
+    This redirects to the latest Release Candidate <a href="PAGES_REDIRECT_URL">here</a>
 </h4>
 </body>
 </html>

--- a/.github/workflows/autopublish.yaml
+++ b/.github/workflows/autopublish.yaml
@@ -19,7 +19,11 @@ jobs:
           chmod +x ./.github/scripts/checkout-tags.sh
           ./.github/scripts/checkout-tags.sh
       - name: Redirect top to head
-        run: cp .github/scripts/index.html .
+        run: |
+          REPO_OWNER="${GITHUB_REPOSITORY%%/*}"
+          REPO_NAME="${GITHUB_REPOSITORY##*/}"
+          PAGES_REDIRECT_URL="https://${REPO_OWNER}.github.io/${REPO_NAME}/2025-1-err1"
+          sed "s|PAGES_REDIRECT_URL|${PAGES_REDIRECT_URL}|g" .github/scripts/index.html > index.html
       - uses: actions/upload-pages-artifact@v3
         with:
           path: .

--- a/WEBSITE.md
+++ b/WEBSITE.md
@@ -38,7 +38,7 @@ When wanting to pin and publish a snapshot in time via a separate url-path, foll
 When the content is finished, a release requires a first commit with
 
 1. a tag with the exact version string (like `2025-1-RC1`) on the release commit
-2. to change the redirect in `.github/scripts/index.html` to point to latest release candidate
+2. to change the redirect target version in `.github/workflows/autopublish.yaml` (`PAGES_REDIRECT_URL`) to point to the latest release candidate (the URL is constructed dynamically from the repository owner and name)
 3. set the `respecConfig.publishDate` in `index.html` to a string like `"2025-02-27"`,`
 4. set the `respecConfig.specStatus` in `index.html` to `base`
 

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/SchemaTableGeneratorPlugin.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/SchemaTableGeneratorPlugin.java
@@ -62,7 +62,7 @@ public class SchemaTableGeneratorPlugin implements Plugin<Project> {
             var schemaModel = parser.parseFiles(stream);
 
             schemaModel.getSchemaTypes().stream()
-                    .filter(type -> !type.isRootDefinition() && !type.isJsonBaseType())  // do not process built-in Json types and root schema types
+                    .filter(type -> !type.isRootDefinition() && !type.isJsonBaseType() && !type.isNamedScalar())  // do not process built-in Json types and root schema types
                     .forEach(type -> {
                         var content = htmlTransformer.transform(type);
                         var destination = new File(tablesDir, type.getName().toLowerCase() + ".html");

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/JsomParser.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/JsomParser.java
@@ -146,6 +146,10 @@ public class JsomParser {
         var itemType = parseItemType(definition, baseType);
         var context = prefix + schemaPath.substring(resolutionPath.length());
         var schemaType = new SchemaType(type, baseType, itemType, context);
+        var enumValues = (List<Object>) definition.get(ENUM);
+        if (enumValues != null) {
+            schemaType.enumValues(enumValues);
+        }
         parseAttributes(definition, schemaType);
         return schemaType;
     }
@@ -209,10 +213,11 @@ public class JsomParser {
                 .toList();
         schemaType.properties(properties);
 
-        // parse required from inline entries (entries without $ref)
-        constraintDef.stream()
-                .filter(e -> e.get(REF) == null)
-                .forEach(e -> parseRequired(e, schemaType));
+        if (constraintType == ConstraintType.ALL_OF) {
+            constraintDef.stream()
+                    .filter(e -> e.get(REF) == null)
+                    .forEach(e -> parseRequired(e, schemaType));
+        }
 
         // parse references
         var references = constraintDef

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/JsomParser.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/JsomParser.java
@@ -209,6 +209,11 @@ public class JsomParser {
                 .toList();
         schemaType.properties(properties);
 
+        // parse required from inline entries (entries without $ref)
+        constraintDef.stream()
+                .filter(e -> e.get(REF) == null)
+                .forEach(e -> parseRequired(e, schemaType));
+
         // parse references
         var references = constraintDef
                 .stream()

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaModelContext.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaModelContext.java
@@ -121,20 +121,22 @@ public class SchemaModelContext implements SchemaModel {
                 .stream()
                 .filter(ref -> ref.getResolvedProperty() == null)
                 .forEach(ref -> {
-                    // check in allOf
+                    // check in allOf (transitively, since properties may be defined in nested allOf entries)
                     var resolved = type.getResolvedAllOf().stream()
-                            .flatMap(t -> t.getProperties().stream()
+                            .flatMap(t -> t.getTransitiveProperties().stream()
                                     .map(p -> p.getName().equals(ref.getName()) ? p : null)
                                     .filter(Objects::nonNull)).findFirst().orElse(null);
 
-                    ref.resolvedProperty(resolved);
+                    if (resolved == null) {
+                        resolved = type.getResolvedOneOf().stream()
+                                .flatMap(t -> t.getTransitiveProperties().stream()
+                                        .map(p -> p.getName().equals(ref.getName()) ? p : null)
+                                        .filter(Objects::nonNull)).findFirst().orElse(null);
+                    }
 
-                    resolved = type.getResolvedOneOf().stream()
-                            .flatMap(t -> t.getProperties().stream()
-                                    .map(p -> p.getName().equals(ref.getName()) ? p : null)
-                                    .filter(Objects::nonNull)).findFirst().orElse(null);
-
-                    ref.resolvedProperty(resolved);
+                    if (resolved != null) {
+                        ref.resolvedProperty(resolved);
+                    }
                 }));
 
 

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaType.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaType.java
@@ -54,6 +54,7 @@ public class SchemaType implements Comparable<SchemaType> {
     private final Map<String, SchemaPropertyReference> optionalProperties = new HashMap<>();
 
     private boolean jsonBaseType; // denotes if this type represents a base Json type, e.g. string, object, array
+    private final Set<Object> enumValues = new TreeSet<>();
 
     /**
      * Ctor for base Json types.
@@ -108,6 +109,18 @@ public class SchemaType implements Comparable<SchemaType> {
 
     public String getSchemaUri() {
         return schemaUri;
+    }
+
+    public Set<Object> getEnumValues() {
+        return enumValues;
+    }
+
+    public void enumValues(Collection<Object> values) {
+        enumValues.addAll(values);
+    }
+
+    public boolean isNamedScalar() {
+        return !jsonBaseType && properties.isEmpty() && resolvedAllOf.isEmpty() && resolvedOneOf.isEmpty();
     }
 
     @NotNull

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaType.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/jsom/SchemaType.java
@@ -115,6 +115,14 @@ public class SchemaType implements Comparable<SchemaType> {
         return properties;
     }
 
+    @NotNull
+    public Set<SchemaProperty> getTransitiveProperties() {
+        return concat(properties.stream(),
+                concat(resolvedAllOf.stream().flatMap(t -> t.getTransitiveProperties().stream()),
+                        resolvedOneOf.stream().flatMap(t -> t.getTransitiveProperties().stream())))
+                .collect(toCollection(TreeSet::new));
+    }
+
     public Collection<SchemaPropertyReference> getRequiredProperties() {
         return requiredProperties.values();
     }
@@ -129,8 +137,8 @@ public class SchemaType implements Comparable<SchemaType> {
 
     @NotNull
     public Set<SchemaPropertyReference> getTransitiveOptionalProperties() {
-        // a type may include multiple other types (allOf) where a property is optional in one but mandatory in another - filter it
-        var required = getRequiredProperties().stream().map(SchemaPropertyReference::getName).collect(Collectors.toSet());
+        // a type may include multiple other types (allOf/oneOf) where a property is optional in one but mandatory in another - filter it
+        var required = getTransitiveRequiredProperties().stream().map(SchemaPropertyReference::getName).collect(Collectors.toSet());
         return concat(optionalProperties.values().stream(),
                 concat(resolvedAllOf.stream().flatMap(type -> type.getTransitiveOptionalProperties().stream()),
                 resolvedOneOf.stream().flatMap(type -> type.getTransitiveOptionalProperties().stream())))

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/transformer/HtmlTableTransformer.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/transformer/HtmlTableTransformer.java
@@ -40,6 +40,10 @@ public class HtmlTableTransformer implements SchemaTypeTransformer<String> {
     public String transform(SchemaType schemaType) {
         var builder = new StringBuilder(CSS).append("<table class=\"message-table\">");
         builder.append(format("<tr><td class=\"message-class\" colspan=\"4\" id=\"%s-table\">%s</td></tr>", schemaType.getName(), schemaType.getName()));
+        if (!schemaType.getEnumValues().isEmpty()) {
+            var values = schemaType.getEnumValues().stream().map(Object::toString).collect(Collectors.joining(", "));
+            builder.append(format("<tr><td colspan=\"4\"><span class=\"code\">%s</span></td></tr>", values));
+        }
         transformProperties(schemaType.getTransitiveRequiredProperties(), true, builder);
         transformProperties(schemaType.getTransitiveOptionalProperties(), false, builder);
         return builder.append("</table>").toString();
@@ -64,7 +68,22 @@ public class HtmlTableTransformer implements SchemaTypeTransformer<String> {
                 resolvedTypes = parseResolvedTypes(resolvedProperty);
             }
             builder.append(format("<td>%s</td>", resolvedTypes));
-            if (resolvedProperty.getConstantValue() != null) {
+
+            // if all resolved types are named scalars, render their base type and enum values
+            var namedScalars = resolvedProperty.getResolvedTypes().stream()
+                    .filter(this::isNamedScalar)
+                    .toList();
+            if (!namedScalars.isEmpty() && namedScalars.size() == resolvedProperty.getResolvedTypes().size()) {
+                var enumValues = namedScalars.stream()
+                        .flatMap(t -> t.getEnumValues().stream())
+                        .map(Object::toString)
+                        .collect(Collectors.joining(", "));
+                if (!enumValues.isEmpty()) {
+                    builder.append(format("<td>Must be one of:<br><span class=\"code\">%s</span></td>", enumValues));
+                } else {
+                    builder.append(format("<td>%s</td>", resolvedProperty.getDescription()));
+                }
+            } else if (resolvedProperty.getConstantValue() != null) {
                 builder.append(format("<td>Value must be <span class=\"code\">%s</span></td>", resolvedProperty.getConstantValue()));
             } else if (!resolvedProperty.getEnumValues().isEmpty()) {
                 var values = resolvedProperty.getEnumValues().stream()
@@ -88,6 +107,10 @@ public class HtmlTableTransformer implements SchemaTypeTransformer<String> {
         builder.append("</tr>");
     }
 
+    private boolean isNamedScalar(SchemaType schemaType) {
+        return schemaType.isNamedScalar();
+    }
+
     private String parseResolvedTypes(SchemaProperty property) {
         if (!property.getItemTypes().isEmpty()) {
             return "";
@@ -96,6 +119,9 @@ public class HtmlTableTransformer implements SchemaTypeTransformer<String> {
                 .map(schemaType -> {
                     if (schemaType.getItemType() != null) {
                         return "array[" + schemaType.getItemType() + "]";
+                    }
+                    if (isNamedScalar(schemaType)) {
+                        return schemaType.getBaseType();
                     }
                     return typeNameWithLink(schemaType);
                 })

--- a/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/transformer/HtmlTableTransformer.java
+++ b/artifacts/buildSrc/src/main/java/org/eclipse/dsp/generation/transformer/HtmlTableTransformer.java
@@ -89,38 +89,28 @@ public class HtmlTableTransformer implements SchemaTypeTransformer<String> {
     }
 
     private String parseResolvedTypes(SchemaProperty property) {
-        String resolvedTypes = "";
-        if (property.getItemTypes().isEmpty()) {
-            resolvedTypes = property
-                    .getResolvedTypes().stream().map(schemaType -> {
-                        if (schemaType.getItemType() != null) {
-                            return "array[" + schemaType.getItemType() + "]";
-                        }
-                        return getTypeName(schemaType);
-                    }).collect(joining(", "));
+        if (!property.getItemTypes().isEmpty()) {
+            return "";
         }
-        return resolvedTypes;
+        return property.getResolvedTypes().stream()
+                .map(schemaType -> {
+                    if (schemaType.getItemType() != null) {
+                        return "array[" + schemaType.getItemType() + "]";
+                    }
+                    return typeNameWithLink(schemaType);
+                })
+                .collect(joining(", "));
     }
 
     private @NotNull String getConstraintOrArrayTypeName(SchemaProperty resolvedProperty) {
         var itemTypes = resolvedProperty.getItemTypes().stream()
                 .flatMap(t -> t.getResolvedTypes().stream())
-                .map(e -> {
-                    if (e.isJsonBaseType() || getTypeName(e).startsWith("array")) {
-                        return String.format("%s", getTypeName(e));
-                    }
-                    return String.format("<a href=#%s-table>%s</a>", getTypeName(e), getTypeName(e));
-                })
+                .map(this::typeNameWithLink)
                 .collect(joining(", "));
         if (itemTypes.isEmpty()) {
             itemTypes = resolvedProperty.getResolvedTypes().stream()
                     .filter(e -> getTypeName(e) != null)
-                    .map(e -> {
-                        if (e.isJsonBaseType()) {
-                            return String.format("%s", getTypeName(e));
-                        }
-                        return String.format("<a href=#%s-table>%s</a>", getTypeName(e), getTypeName(e));
-                    })
+                    .map(this::typeNameWithLink)
                     .collect(joining(", "));
             if (itemTypes.isEmpty()) {
                 return "array";
@@ -136,6 +126,14 @@ public class HtmlTableTransformer implements SchemaTypeTransformer<String> {
             return "not [" + itemTypes + "]";
         }
         return "array[" + itemTypes + "]";
+    }
+
+    private String typeNameWithLink(SchemaType schemaType) {
+        var name = getTypeName(schemaType);
+        if (name == null || schemaType.isJsonBaseType() || name.startsWith("array")) {
+            return name;
+        }
+        return String.format("<a href=#%s-table>%s</a>", name, name);
     }
 
     private String getTypeName(SchemaType schemaType) {

--- a/specifications/common/type.definitions.md
+++ b/specifications/common/type.definitions.md
@@ -1,8 +1,5 @@
 # Lower Level Type Definitions
 
-<p data-include="message/table/action.html" data-include-format="html">
-</p>
-
 <p data-include="message/table/agreement.html" data-include-format="html">
 </p>
 
@@ -30,25 +27,16 @@
 <p data-include="message/table/endpointproperty.html" data-include-format="html">
 </p>
 
-<p data-include="message/table/leftoperand.html" data-include-format="html">
-</p>
-
 <p data-include="message/table/messageoffer.html" data-include-format="html">
 </p>
 
 <p data-include="message/table/offer.html" data-include-format="html">
 </p>
 
-<p data-include="message/table/operator.html" data-include-format="html">
-</p>
-
 <p data-include="message/table/permission.html" data-include-format="html">
 </p>
 
 <p data-include="message/table/prohibition.html" data-include-format="html">
-</p>
-
-<p data-include="message/table/rightoperand.html" data-include-format="html">
 </p>
 
 <p data-include="message/table/rule.html" data-include-format="html">

--- a/specifications/common/type.definitions.md
+++ b/specifications/common/type.definitions.md
@@ -1,5 +1,8 @@
 # Lower Level Type Definitions
 
+<p data-include="message/table/action.html" data-include-format="html">
+</p>
+
 <p data-include="message/table/agreement.html" data-include-format="html">
 </p>
 
@@ -27,16 +30,25 @@
 <p data-include="message/table/endpointproperty.html" data-include-format="html">
 </p>
 
+<p data-include="message/table/leftoperand.html" data-include-format="html">
+</p>
+
 <p data-include="message/table/messageoffer.html" data-include-format="html">
 </p>
 
 <p data-include="message/table/offer.html" data-include-format="html">
 </p>
 
+<p data-include="message/table/operator.html" data-include-format="html">
+</p>
+
 <p data-include="message/table/permission.html" data-include-format="html">
 </p>
 
 <p data-include="message/table/prohibition.html" data-include-format="html">
+</p>
+
+<p data-include="message/table/rightoperand.html" data-include-format="html">
 </p>
 
 <p data-include="message/table/rule.html" data-include-format="html">


### PR DESCRIPTION
## Summary
- Fix missing/duplicate properties and incorrect required/optional and enum rendering in generated type tables
- Render non-primitive scalar property types as links
- Add Action, LeftOperand, Operator, RightOperand to lower-level type definitions
- Fix GitHub Pages redirect URL derivation from repository context

status ex post: https://arnoweiss.github.io/DataspaceProtocol/HEAD/#Constraint-table
status ex ante: https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/HEAD/#Constraint-table

closes #238