### PR TITLE
fix(transfer): correct Transfer Suspension Message property table reference

### DIFF
--- a/specifications/transfer/transfer.process.protocol.md
+++ b/specifications/transfer/transfer.process.protocol.md
@@ -159,7 +159,7 @@ The Transfer Start Message is sent by the [=Provider=] to indicate the data tran
 | **Response**        | [ACK](#ack-transfer-process) or [ERROR](#error-transfer-error)                             |
 | **Schema**          | [JSON Schema](message/schema/transfer-suspension-message-schema.json)                      |
 | **Example**         | [Message](message/example/transfer-suspension-message.json)                                |
-| **Properties**      | <p data-include="message/table/transferstartmessage.html" data-include-format="html"></p> |
+| **Properties**      | <p data-include="message/table/transfersuspensionmessage.html" data-include-format="html"></p> |
 
 The Transfer Suspension Message is sent by the [=Provider=] or [=Consumer=] when either of them needs to temporarily
 suspend the [=Transfer Process=].


### PR DESCRIPTION
## Summary
- Fixes wrong `data-include` reference in the Transfer Suspension Message section of the transfer protocol spec
- The section was incorrectly including `transferstartmessage.html` instead of `transfersuspensionmessage.html`, causing Transfer Start Message field descriptions to render under the Transfer Suspension Message heading

Closes #243