### PR TITLE
fix(transfer): clarify TransferStartMessage can be sent by consumer

### DIFF
--- a/specifications/transfer/transfer.process.protocol.md
+++ b/specifications/transfer/transfer.process.protocol.md
@@ -131,7 +131,7 @@ again, the [=Provider=] SHOULD respond with an appropriate [Transfer Start Messa
 
 |                     |                                                                                            |
 |---------------------|--------------------------------------------------------------------------------------------|
-| **Sent by**         | [=Provider=]                                                                               |
+| **Sent by**         | [=Provider=], or [=Consumer=] if transfer process is `SUSPENDED`.                        |
 | **Resulting state** | `STARTED`                                                                                  |
 | **Response**        | [ACK](#ack-transfer-process) or [ERROR](#error-transfer-error)                             |
 | **Schema**          | [JSON Schema](message/schema/transfer-start-message-schema.json)                           |


### PR DESCRIPTION
Closes #252

Amends the `TransferStartMessage` "Sent by" field to reflect that the Consumer may also send it when the transfer process is `SUSPENDED`.