### PR TITLE
chore: publish 2025-1-RC5

### DIFF
--- a/.github/scripts/index.html
+++ b/.github/scripts/index.html
@@ -3,12 +3,12 @@
 <head>
     <meta charset="utf-8">
     <meta http-equiv="refresh"
-          content="0;url=https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1"/>
-    <link rel="canonical" href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1"/>
+          content="0;url=https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC5"/>
+    <link rel="canonical" href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC5"/>
 </head>
 <body>
 <h4>
-    This redirects to the latest Release Candidate <a href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1">here</a>
+    This redirects to the latest Release Candidate <a href="https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-RC5">here</a>
 </h4>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
     <script src='https://www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: "unofficial",
+            specStatus: "base",
+            publishDate: "2026-08-31",
             latestVersion: "https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1",
             editors: [{
                name: "Sebastian Steinbuss",
@@ -80,7 +81,7 @@
             },
         };
     </script>
-    <title>Dataspace Protocol Release 2025-1</title>
+    <title>Dataspace Protocol Release 2025-1-RC5</title>
 </head>
 <body>
 <p class="copyright">
@@ -88,7 +89,7 @@
     <br/>
     Copyright © 2026 The Eclipse Foundation AISBL
 </p>
-<h1 id="title">Dataspace Protocol 2025-1</h1>
+<h1 id="title">Dataspace Protocol 2025-1-RC5</h1>
 <section id='abstract'>
     <p>
         The Dataspace Protocol is a specification designed to facilitate interoperable data sharing between

--- a/index.html
+++ b/index.html
@@ -5,8 +5,7 @@
     <script src='https://www.w3.org/Tools/respec/respec-w3c' async class='remove'></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: "base",
-            publishDate: "2026-08-31",
+            specStatus: "unofficial",
             latestVersion: "https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1-err1",
             editors: [{
                name: "Sebastian Steinbuss",


### PR DESCRIPTION
## What this PR changes/adds

- `index.html`: `specStatus` → `"base"`, adds `publishDate`, title/`<h1>` →
  `2025-1-RC5` (commit `chore: publish 2025-1-RC5`)
- `index.html`: reverts `specStatus` back to `"unofficial"`, removes
  `publishDate` (commit `chore: start work on next revision`)
- `.github/scripts/index.html`: redirect, canonical link, and visible link
  text updated from `2025-1-err1` to `2025-1-RC5`

## Why it does that

Publishes a release candidate reflecting the terminology and bibliography
changes from #267.

## ⚠️ Merge method

**Merge with "Rebase and merge", not "Squash and merge."** Squashing drops
the intermediate `specStatus: "base"` commit that the `2025-1-RC5` tag needs
to point at — see #<issue-number> for why (this already happened once, for
2025-1-RC4 / PR #206).

## Linked Issue(s)

Closes #269 