### PR TITLE
fix: add localBiblio fallback for SpecRef-resolved references

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,54 @@
                     publisher: "ISO/IEC",
                     date: "November 1994",
                 },
+                "json-schema": {
+                    title: "JSON Schema: A Media Type for Describing JSON Documents",
+                    href: "https://json-schema.org/draft/2020-12/json-schema-core",
+                    publisher: "IETF (Internet Engineering Task Force)",
+                    status: "Internet-Draft",
+                },
+                "RFC2119": {
+                    title: "RFC 2119 Key words for use in RFCs to Indicate Requirement Levels",
+                    href: "https://www.rfc-editor.org/rfc/rfc2119",
+                    publisher: "IETF",
+                    date: "March 1997",
+                },
+                "RFC8174": {
+                    title: "RFC 8174 Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words",
+                    href: "https://www.rfc-editor.org/rfc/rfc8174",
+                    publisher: "IETF",
+                    date: "May 2017",
+                },
+                "rfc3987": {
+                    title: "RFC 3987 Internationalized Resource Identifiers (IRIs)",
+                    href: "https://www.rfc-editor.org/rfc/rfc3987",
+                    publisher: "IETF",
+                    date: "January 2005",
+                },
+                "rfc8615": {
+                    title: "RFC 8615 Well-Known Uniform Resource Identifiers (URIs)",
+                    href: "https://www.rfc-editor.org/rfc/rfc8615",
+                    publisher: "IETF",
+                    date: "May 2019",
+                },
+                "did-core": {
+                    title: "Decentralized Identifiers (DIDs) v1.0: Core architecture, data model, and representations",
+                    href: "https://www.w3.org/TR/did-core/",
+                    publisher: "W3C",
+                    date: "19 July 2022",
+                },
+                "vocab-dcat-3": {
+                    title: "Data Catalog Vocabulary (DCAT) - Version 3",
+                    href: "https://www.w3.org/TR/vocab-dcat-3/",
+                    publisher: "W3C",
+                    date: "22 August 2024",
+                },
+                "odrl-model": {
+                    title: "ODRL Information Model 2.2",
+                    href: "https://www.w3.org/TR/odrl-model/",
+                    publisher: "W3C",
+                    date: "15 February 2018",
+                },
             },
         };
     </script>


### PR DESCRIPTION
## Status

Standby fix — not merging yet. api.specref.org's DNS is currently broken
(confirmed: even the last published release, 2025-1-err1, shows the same
"Reference not found" errors for every SpecRef-resolved reference). We're
waiting to see if the service recovers on its own before deciding whether
to merge this. Keeping it ready as a draft in case it doesn't.

## What this PR changes/adds

Adds `localBiblio` entries for the 8 references that were resolving through
SpecRef: `json-schema`, `RFC2119`, `RFC8174`, `rfc3987`, `rfc8615`,
`did-core`, `vocab-dcat-3`, `odrl-model`.

## Why it does that

`api.specref.org`'s DNS points to a Heroku subdomain
(`api.specref.org.herokudns.com`) that doesn't resolve any further — a dead
backend, not a transient blip. This makes the whole document independent of
that external service's availability, regardless of whether/when it comes
back.

Note: `RFC2119` and `RFC8174` aren't cited anywhere in our markdown —
ReSpec auto-injects them into the Conformance section for any document
using RFC 2119 keywords (MUST/SHOULD/MAY), which this spec does throughout.

## Verification

Bibliographic data pulled from each spec's own canonical page (W3C TR pages,
RFC Editor, json-schema.org), not from the (currently unreachable) SpecRef
API. Verified the `respecConfig` object still parses as valid JS with all 11
`localBiblio` keys present.